### PR TITLE
Fix hard-coded SKIP_CLAMD

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -181,7 +181,7 @@ SKIP_IP_CHECK=n
 
 # Skip ClamAV (clamd-mailcow) anti-virus (Rspamd will auto-detect a missing ClamAV container) - y/n
 
-SKIP_CLAMD=n
+SKIP_CLAMD=${SKIP_CLAMD}
 
 # Skip Solr on low-memory systems
 SKIP_SOLR=${SKIP_SOLR}


### PR DESCRIPTION
The option to disable ClamAv when less than 2.5 GiB memory dose not work as SKIP_CLAMD is hard-coded to no.