### PR TITLE
Support for app-passwords in Cal-, CardDav & ActiveSync

### DIFF
--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -68,8 +68,7 @@ if (empty($_SERVER['PHP_AUTH_USER']) || empty($_SERVER['PHP_AUTH_PW'])) {
   exit(0);
 }
 
-$allow_app_passwords = $ALLOW_APP_PASSWORDS_IN_EAS === true || $autodiscover_config['autodiscoverType'] == 'imap';
-$login_role = check_login($login_user, $login_pass, $allow_app_passwords);
+$login_role = check_login($login_user, $login_pass, true);
 
 if ($login_role === "user") {
   header("Content-Type: application/xml");

--- a/data/web/inc/vars.inc.php
+++ b/data/web/inc/vars.inc.php
@@ -188,9 +188,6 @@ $MAILBOX_DEFAULT_ATTRIBUTES['mailbox_format'] = 'maildir:';
 // Show last IMAP and POP3 logins
 $SHOW_LAST_LOGIN = true;
 
-// Allow app passwords in CardDav, CalDav and ActiveSync
-$ALLOW_APP_PASSWORDS_IN_EAS = true;
-
 // UV flag handling in FIDO2/WebAuthn - defaults to false to allow iOS logins
 // true = required
 // false = preferred

--- a/data/web/sogo-auth.php
+++ b/data/web/sogo-auth.php
@@ -15,7 +15,7 @@ if (isset($_SERVER['PHP_AUTH_USER'])) {
   $username = $_SERVER['PHP_AUTH_USER'];
   $password = $_SERVER['PHP_AUTH_PW'];
   $is_eas = preg_match('/^(\/SOGo|)\/(dav|Microsoft-Server-ActiveSync).*/', $_SERVER['HTTP_X_ORIGINAL_URI']);
-  $login_check = check_login($username, $password, $is_eas && $ALLOW_APP_PASSWORDS_IN_EAS);
+  $login_check = check_login($username, $password, $is_eas);
   if ($login_check === 'user') {
     header("X-User: $username");
     header("X-Auth: Basic ".base64_encode("$username:$password"));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: mailcow/sogo:1.101
+      image: mailcow/sogo:1.102
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}


### PR DESCRIPTION
This PR adds support for app passwords to the missing 3 protocols, Cal-, CardDav & ActiveSync so that devices can be fully managed with app passwords and tools like `vdirsyncer` can be used for continuous calendar+contact backup/sync without a need to use the own user password for that.

There are multiple cases where such a feature was mentioned, e.g.: #3710. When checking the changes with CalDav, CardDav & ActiveSync on Android, iOS, MacOS and Win10, I couldn't find any technical issues, all just worked fine.

Atm there is no enforcement for app passwords as proposed in some cases especially when 2FA is also enabled (e.g. #3869) but it could be added as a configuration option to disallow login with normal passwords in `dovecot` and `sogo-auth.php`. I'm open to extend the PR but I tried to keep it simple at first. UI will also need an update to tell that app passwords are not limited to imap and smtp.