### PR TITLE
Add Watchdog verbose logging

### DIFF
--- a/data/Dockerfiles/watchdog/Dockerfile
+++ b/data/Dockerfiles/watchdog/Dockerfile
@@ -36,4 +36,4 @@ RUN apk add --update \
 COPY watchdog.sh /watchdog.sh
 COPY check_mysql_slavestatus.sh /usr/lib/nagios/plugins/check_mysql_slavestatus.sh
 
-CMD /watchdog.sh 2> /dev/null
+CMD /watchdog.sh

--- a/data/Dockerfiles/watchdog/watchdog.sh
+++ b/data/Dockerfiles/watchdog/watchdog.sh
@@ -6,7 +6,10 @@ trap "kill 0" EXIT
 # Prepare
 BACKGROUND_TASKS=()
 echo "Waiting for containers to settle..."
-sleep 30
+for i in {30..1}; do
+  echo "${i}"
+  sleep 1
+done
 
 if [[ "${USE_WATCHDOG}" =~ ^([nN][oO]|[nN])+$ ]]; then
   echo -e "$(date) - USE_WATCHDOG=n, skipping watchdog..."
@@ -16,8 +19,10 @@ fi
 
 if [[ "${WATCHDOG_VERBOSE}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
   SMTP_VERBOSE="--verbose"
+  set -xv
 else
   SMTP_VERBOSE=""
+  exec 2>/dev/null
 fi
 
 # Checks pipe their corresponding container name in this pipe
@@ -143,7 +148,11 @@ function mail_error() {
     if [[ $? -eq 1 ]]; then # exit code 1 is fine
       log_msg "Sent notification email to ${rcpt}"
     else
-      log_msg "Error while sending notification email to ${rcpt}. You can enable verbose logging by setting 'WATCHDOG_VERBOSE=y' in mailcow.conf."
+      if [[ "${SMTP_VERBOSE}" == "" ]]; then
+        log_msg "Error while sending notification email to ${rcpt}. You can enable verbose logging by setting 'WATCHDOG_VERBOSE=y' in mailcow.conf."
+      else
+        log_msg "Error while sending notification email to ${rcpt}."
+      fi
     fi
   done
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -444,8 +444,6 @@ services:
 
     watchdog-mailcow:
       image: mailcow/watchdog:1.95
-      # Debug
-      #command: /watchdog.sh
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       tmpfs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -443,7 +443,7 @@ services:
         - /lib/modules:/lib/modules:ro
 
     watchdog-mailcow:
-      image: mailcow/watchdog:1.94
+      image: mailcow/watchdog:1.95
       # Debug
       #command: /watchdog.sh
       dns:
@@ -470,6 +470,7 @@ services:
         - WATCHDOG_SUBJECT=${WATCHDOG_SUBJECT:-Watchdog ALERT}
         - WATCHDOG_EXTERNAL_CHECKS=${WATCHDOG_EXTERNAL_CHECKS:-n}
         - WATCHDOG_MYSQL_REPLICATION_CHECKS=${WATCHDOG_MYSQL_REPLICATION_CHECKS:-n}
+        - WATCHDOG_VERBOSE=${WATCHDOG_VERBOSE:-n}
         - MAILCOW_HOSTNAME=${MAILCOW_HOSTNAME}
         - COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME:-mailcow-dockerized}
         - IPV4_NETWORK=${IPV4_NETWORK:-172.22.1}

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -287,6 +287,9 @@ WATCHDOG_NOTIFY_BAN=n
 # Will only work with unmodified mailcow setups.
 WATCHDOG_EXTERNAL_CHECKS=n
 
+# Enable watchdog verbose logging
+WATCHDOG_VERBOSE=n
+
 # Max log lines per service to keep in Redis logs
 
 LOG_LINES=9999

--- a/update.sh
+++ b/update.sh
@@ -513,6 +513,11 @@ for option in ${CONFIG_ARRAY[@]}; do
       echo '# https://mailcow.github.io/mailcow-dockerized-docs/debug-reset-tls/' >> mailcow.conf
       echo 'ACME_CONTACT=' >> mailcow.conf
   fi
+elif [[ ${option} == "WATCHDOG_VERBOSE" ]]; then
+    if ! grep -q ${option} mailcow.conf; then
+      echo '# Enable watchdog verbose logging' >> mailcow.conf
+      echo 'WATCHDOG_VERBOSE=n' >> mailcow.conf
+  fi
   elif ! grep -q ${option} mailcow.conf; then
     echo "Adding new option \"${option}\" to mailcow.conf"
     echo "${option}=n" >> mailcow.conf


### PR DESCRIPTION
Adding the possibility to see verbose logs while sending mails via Watchdog
May fix https://github.com/mailcow/mailcow-dockerized/issues/4298 + https://github.com/mailcow/mailcow-dockerized/issues/4197


PS: Needs a new watchdog image then
PPS: Needs more testing - only tested it quickly. @andryyy maybe you have some time for this