### PR TITLE
[Web] Skip update_sogo_static_view if sogo is disabled

### DIFF
--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -5264,7 +5264,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
       }
     break;
   }
-  if ($_action != 'get' && in_array($_type, array('domain', 'alias', 'alias_domain', 'mailbox', 'resource'))) {
+  if ($_action != 'get' && in_array($_type, array('domain', 'alias', 'alias_domain', 'mailbox', 'resource')) && getenv('SKIP_SOGO') != "y") {
     update_sogo_static_view();
   }
 }


### PR DESCRIPTION
When creating a mailbox, the sogo_static_view needs to be adjusted. This adjustment leads to the fact that with each existing mailbox, the creation of a new mailbox takes longer.
However, the function is only needed if SOGo is enabled. We can skip the function for setups without SOGo and thus improve the performance when creating a mailbox.

https://github.com/mailcow/mailcow-dockerized/issues/4980