### PR TITLE
[netfilter] add pubsub exception

### DIFF
--- a/data/Dockerfiles/netfilter/server.py
+++ b/data/Dockerfiles/netfilter/server.py
@@ -332,7 +332,7 @@ def watch():
               logWarn('%s matched rule id %s (%s)' % (addr, rule_id, item['data']))
               ban(addr)
     except Exception as ex:
-      logWarn('Error reading log line from pubsub')
+      logWarn('Error reading log line from pubsub: %s' % ex)
       quit_now = True
       exit_code = 2
 


### PR DESCRIPTION
#5125 is dificult to debug, as the exception is not printed to the logs. This PR changes that.