### PR TITLE
Redirect to original page or SOGo after user login

### DIFF
--- a/data/conf/sogo/custom-sogo.js
+++ b/data/conf/sogo/custom-sogo.js
@@ -2,7 +2,7 @@
 document.addEventListener('DOMContentLoaded', function () {
     var loginForm = document.forms.namedItem("loginForm");
     if (loginForm) {
-        window.location.href = '/user';
+        window.location.href = '/user?sogo';
     }
 });
 // logout function
@@ -13,7 +13,8 @@ function mc_logout() {
           "Content-Type": "application/x-www-form-urlencoded"
         },
         body: "logout=1"
-    }).then(() => window.location.href = '/');
+        // Force set next redirect back to SOGo to prevent race condition where sometimes it is set, other times it isn't
+    }).then(() => window.location.href = '/?next=user%3Fsogo');
 }
 
 // Custom SOGo JS

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -287,6 +287,37 @@ function password_check($password1, $password2) {
 
   return true;
 }
+function valid_redirect($uri) {
+  if (false !== ($i = strpos($uri, '\\')) && $i < strcspn($uri, '?#')) {
+    // Backslash may not precede URI query/fragment
+    return false;
+  } else if (strlen($uri) !== strcspn($uri, "\r\n\t")) {
+    // Carriage return, new line and tab are all invalid
+    return false;
+  } else if ('' !== $uri && (ord($uri[0]) <= 32 || ord($uri[-1]) <= 32)) {
+    // Ensure string starts/ends with non-control characters/space
+    return false;
+  } else if (0 === strcspn($uri, "/:;<>\"'")) {
+    // A valid redirect probably isn't going to start with these commonly abused characters
+    return false;
+  } else if (str_starts_with($uri, "http:") || str_starts_with($uri, "https:") || str_starts_with($uri, "javascript:")) {
+    // Probably shouldn't start with these either
+    return false;
+  }
+  return true;
+}
+/**
+ * Constructs a redirect URI or null, if invalid
+ */
+function construct_redirect($uri) {
+  if (valid_redirect($uri)) {
+    $protocol = stripos($_SERVER['SERVER_PROTOCOL'], 'https') === 0 ? 'https' : 'http';
+    return $protocol . '://' . $_SERVER['HTTP_HOST'] . '/' . $uri;
+  } else {
+    // If redirect seems weird, just fail
+    return null;
+  }
+}
 function last_login($action, $username, $sasl_limit_days = 7, $ui_offset = 1) {
   global $pdo;
   global $redis;
@@ -3026,6 +3057,19 @@ function identity_provider($_action = null, $_data = null, $_extra = null) {
       if ($iam_settings['authsource'] != 'keycloak' && $iam_settings['authsource'] != 'generic-oidc')
         return false;
       $options = [];
+      // Check if redirect is of a reasonable length to ensure it doesn't break the OAuth state
+      if (isset($_GET['next']) && strlen($_GET['next']) <= 128 && valid_redirect($_GET['next'])) {
+        // Store next redirect URL to state for persistence
+        // It is preferable to store it with the OAuth state, because that must be cleared
+        // by mailcow and the OAuth provider. This helps prevent accidental redirects
+        // from stale session data and makes the behavior more intuitive.
+
+        // State must be less than approximately 2000 characters
+        $options['state'] = base64_encode(json_encode(array(
+          'random' => bin2hex(random_bytes(32 /* String length = 32 */ / 2)), // Add some random data to make state less predictable
+          'next' => $_GET['next'],
+        )));
+      }
       if (isset($iam_settings['redirect_url_extra'])) {
         // check if the current domain is used in an extra redirect URL
         $targetDomain = strtolower($_SERVER['HTTP_HOST']);
@@ -3503,7 +3547,8 @@ function protect_route($allowed_roles = ['admin', 'domainadmin', 'user'], $redir
     if (isset($redirects['unauthenticated'])) {
       header('Location: ' . $redirects['unauthenticated']);
     } else {
-      header('Location: /');
+      // Save current URL so the user can be redirected back after login
+      header('Location: /?next=' . rawurlencode(ltrim($_SERVER['REQUEST_URI'], '/')));
     }
     exit();
   }

--- a/data/web/inc/triggers.user.inc.php
+++ b/data/web/inc/triggers.user.inc.php
@@ -23,7 +23,13 @@ if ($iam_provider){
     // Check given state against previously stored one to mitigate CSRF attack
     // Received access token in $_GET['code']
     // extract info and verify user
-    identity_provider('verify-sso');
+    if (identity_provider('verify-sso')) {
+      $decoded_state = json_decode(base64_decode($_GET['state']));
+      if (!is_null($decoded_state) && is_object($decoded_state) && isset($decoded_state->next)) {
+        // Restore next parameter for redirection later
+        $_GET['next'] = $decoded_state->next;
+      }
+    }
   }
 }
 
@@ -80,6 +86,14 @@ if (isset($_POST["verify_tfa_login"])) {
         if (!empty($_SESSION['pending_tfa_setup']) || !empty($_SESSION['pending_pw_update'])) {
           header("Location: /");
           die();
+        }
+        if (isset($_GET['next'])) {
+          // If redirect is null, fail to default to be safe
+          $final_redirect = construct_redirect(rawurldecode($_GET['next']));
+          if ($final_redirect != null) {
+            header("Location: " . $final_redirect);
+            die();
+          }
         }
         if (intval($user_details['attributes']['sogo_access']) == 1 &&
             intval($user_details['attributes']['force_pw_update']) != 1 &&
@@ -160,6 +174,14 @@ if (isset($_POST["login_user"]) && isset($_POST["pass_user"])) {
     if (!empty($_SESSION['pending_tfa_setup']) || !empty($_SESSION['pending_pw_update'])) {
       header("Location: /");
       die();
+    }
+    if (isset($_GET['next'])) {
+      // If redirect is null, fail to default to be safe
+      $final_redirect = construct_redirect(rawurldecode($_GET['next']));
+      if ($final_redirect != null) {
+        header("Location: " . $final_redirect);
+        die();
+      }
     }
     if (intval($user_details['attributes']['sogo_access']) == 1 &&
         intval($user_details['attributes']['force_pw_update']) != 1 &&

--- a/data/web/index.php
+++ b/data/web/index.php
@@ -12,7 +12,10 @@ elseif (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == '
   if (empty($_SESSION['pending_tfa_setup']) && empty($_SESSION['pending_pw_update'])) {
     $user_details = mailbox("get", "mailbox_details", $_SESSION['mailcow_cc_username']);
     $is_dual = (!empty($_SESSION["dual-login"]["username"])) ? true : false;
-    if (intval($user_details['attributes']['sogo_access']) == 1 && !$is_dual && getenv('SKIP_SOGO') != "y") {
+    if (isset($_GET['next'])) {
+      // If redirect is null, fail to default to be safe
+      header("Location: " . (construct_redirect(rawurldecode($_GET['next'])) ?? "/user"));
+    } else if (intval($user_details['attributes']['sogo_access']) == 1 && !$is_dual && getenv('SKIP_SOGO') != "y") {
       header("Location: /SOGo/so/");
     } else {
       header("Location: /user");
@@ -56,6 +59,7 @@ $template_data = [
   'is_mobileconfig' => str_contains($_SESSION['index_query_string'], 'mobileconfig'),
   'login_delay' => @$_SESSION['ldelay'],
   'has_iam_sso' => $has_iam_sso,
+  'next_redirect' => @$_GET['next'],
   'custom_login' => $custom_login,
 ];
 

--- a/data/web/quarantine.php
+++ b/data/web/quarantine.php
@@ -2,7 +2,8 @@
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
 
 if (!isset($_SESSION['mailcow_cc_role'])) {
-  header('Location: /');
+  // Save current URL so the user can be redirected back after login
+  header('Location: /?next=' . rawurlencode(ltrim($_SERVER['REQUEST_URI'], '/')));
   exit();
 }
 

--- a/data/web/sogo-auth.php
+++ b/data/web/sogo-auth.php
@@ -76,7 +76,8 @@ elseif (isset($_GET['login'])) {
       }
     }
   }
-  header("Location: /");
+  // Save current URL so the user can be redirected back after login
+  header('Location: /?next=' . rawurlencode(ltrim($_SERVER['REQUEST_URI'], '/')));
   exit;
 }
 // only check for admin-login on sogo GUI requests

--- a/data/web/templates/user_index.twig
+++ b/data/web/templates/user_index.twig
@@ -69,7 +69,7 @@
         {% endif %}
         <div class="d-flex flex-column align-items-center">
           {% if has_iam_sso %}
-          <a class="btn btn-xs-lg btn-secondary w-100 mt-2" style="max-width: 400px;" href="/?iam_sso=1"><i class="bi bi-cloud-arrow-up-fill"></i> {{ lang.admin.iam_sso }}</a>
+          <a class="btn btn-xs-lg btn-secondary w-100 mt-2" style="max-width: 400px;" href="/?iam_sso=1{{ next_redirect is not null ? "&next=" ~ next_redirect : "" }}"><i class="bi bi-cloud-arrow-up-fill"></i> {{ lang.admin.iam_sso }}</a>
           {% endif %}
           {% if custom_login.force_sso != 1 %}
           <a class="btn btn-xs-lg btn-secondary w-100 mt-2" style="max-width: 400px;" href="#" id="fido2-login"><i class="bi bi-shield-fill-check"></i> {{ lang.login.fido2_webauthn }}</a>

--- a/data/web/user.php
+++ b/data/web/user.php
@@ -9,6 +9,12 @@ require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/triggers.user.inc.php';
 // Protect route: user only
 protect_route(['user']);
 
+// SOGo will set ?sogo if user is logged out, so that they can be redirected
+if (isset($_GET['sogo'])) {
+  header("Location: /SOGo/so/");
+  exit();
+}
+
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/header.inc.php';
 $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
 $username = $_SESSION['mailcow_cc_username'];


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->

When the user is logged out and navigates to a page such as /quarantine or /SOGo/so/.... (likely via a bookmark), this will store their URL in the session. Once login is complete, whether done through SSO or Mailcow, it checks if there is a redirect URL stored, and redirects the user there.

Additionally, SOGo redirects to /user?sogo, and the user page checks for the sogo parameter to allow more external control over whether a user is redirected to SOGo or Mailcow.

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- nginx
- sogo

## Did you run tests?

Yes

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->

Tested normal login, redirect to quarantine page and redirect to SOGo after login. Tested with login through Mailcow and OAuth2.

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->

For user login only (not admin or domainadmin), a user can set a bookmark or otherwise be redirected to SOGo or another page, and upon completing login, they are redirected back to their original destination.