### PR TITLE
check_dns: better time measurement

### DIFF
--- a/data/Dockerfiles/watchdog/check_dns.sh
+++ b/data/Dockerfiles/watchdog/check_dns.sh
@@ -19,19 +19,19 @@ if [ -z "$HOST" ]; then
 fi
 
 # run dig and measure the time it takes to run
-START_TIME=$(date +%s%3N)
+START_TIME=$(perl -MTime::HiRes -e 'print Time::HiRes::time')
 dig_output=$(dig +short +timeout=2 +tries=1 "$HOST" @"$SERVER" 2>/dev/null)
 dig_rc=$?
+END_TIME=$(perl -MTime::HiRes -e 'print Time::HiRes::time')
 dig_output_ips=$(echo "$dig_output" | grep -E '^[0-9.]+$' | sort | paste -sd ',' -)
-END_TIME=$(date +%s%3N)
-ELAPSED_TIME=$((END_TIME - START_TIME))
+ELAPSED_TIME=$(perl -e "printf('%.3f', $END_TIME - $START_TIME)")
 
 # validate and perform nagios like output and exit codes
 if [ $dig_rc -ne 0 ] || [ -z "$dig_output" ]; then
   echo "Domain $HOST was not found by the server"
   exit 2
 elif [ $dig_rc -eq 0 ]; then
-  echo "DNS OK: $ELAPSED_TIME ms response time. $HOST returns $dig_output_ips"
+  echo "DNS OK: $ELAPSED_TIME seconds response time. $HOST returns $dig_output_ips"
   exit 0
 else
   echo "Unknown error"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -521,7 +521,7 @@ services:
         - /lib/modules:/lib/modules:ro
 
     watchdog-mailcow:
-      image: ghcr.io/mailcow/watchdog:2.09
+      image: ghcr.io/mailcow/watchdog:2.10
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       tmpfs:


### PR DESCRIPTION
Follow up to https://github.com/mailcow/mailcow-dockerized/pull/6685 
Alpine does not output ms using date, therefore we use perl to get a more accurate measurement of the dns response time.
The script output is now even more similar to nagios check_dns.

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?
An improvement to the check_dns script. DNS response time is now measured more accurate.

### Short Description

An improvement to the check_dns script. DNS response time is now measured more accurate.

###  Affected Containers

- watchdog

## Did you run tests?

### What did you tested?

the check_dns script in the watchdog container on my mailcow server.

### What were the final results? (Awaited, got)

The output of the dns response time is now accurately measured in ms instead of just seconds.