### PR TITLE
[Rspamd] Do not increment rate limit for emails from user to himself

### DIFF
--- a/data/conf/rspamd/lua/rspamd.local.lua
+++ b/data/conf/rspamd/lua/rspamd.local.lua
@@ -454,8 +454,12 @@ rspamd_config:register_symbol({
     local redis_params = rspamd_parse_redis_server('dyn_rl')
     local rspamd_logger = require "rspamd_logger"
     local envfrom = task:get_from(1)
+    local envrcpt = task:get_recipients(1) or {}
     local uname = task:get_user()
     if not envfrom or not uname then
+      return false
+    end
+    if #envrcpt == 1 and envrcpt[1].addr == uname then
       return false
     end
     local uname = uname:lower()

--- a/data/conf/rspamd/lua/rspamd.local.lua
+++ b/data/conf/rspamd/lua/rspamd.local.lua
@@ -459,10 +459,12 @@ rspamd_config:register_symbol({
     if not envfrom or not uname then
       return false
     end
-    if #envrcpt == 1 and envrcpt[1].addr == uname then
+
+    local uname = uname:lower()
+
+    if #envrcpt == 1 and envrcpt[1].addr:lower() == uname then
       return false
     end
-    local uname = uname:lower()
 
     local env_from_domain = envfrom[1].domain:lower() -- get smtp from domain in lower case
 


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [ ] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
Do not increment rate limit for emails from user to only himself, f.e. this is the case for SOGo "Calendar created" and so on...

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
-rspamd

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
tested that rspamd not applies rate limit for emails from user himself and works in other cases as expected

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->
all works as planned