### PR TITLE
remove unnecessary busybox grep check from backup_and_restore script

### DIFF
--- a/helper-scripts/backup_and_restore.sh
+++ b/helper-scripts/backup_and_restore.sh
@@ -86,11 +86,6 @@ else
   CMPS_PRJ=$(echo ${COMPOSE_PROJECT_NAME} | tr -cd "[0-9A-Za-z-_]")
 fi
 
-if grep --help 2>&1 | head -n 1 | grep -q -i "busybox"; then
-  >&2 echo -e "\e[31mBusyBox grep detected on local system, please install GNU grep\e[0m"
-  exit 1
-fi
-
 
 function backup() {
   DATE=$(date +"%Y-%m-%d-%H-%M-%S")


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them


## What does this PR include?

### Short Description

Fixes #6657 by simply removing the unnecessary check.

###  Affected Containers

none, only helper script

## Did you run tests?

### What did you tested?

- Checked man page for potentially unsupported options
- Tried running the script with busybox grep.

### What were the final results? (Awaited, got)

Everything worked. See also https://github.com/mailcow/mailcow-dockerized/issues/6657#issue-3274023985