### PR TITLE
Prevent user login if protocol access has been disabled

### DIFF
--- a/data/conf/dovecot/auth/mailcowauth.php
+++ b/data/conf/dovecot/auth/mailcowauth.php
@@ -86,7 +86,7 @@ if ($result === false){
     'remote_addr' => $post['real_rip']
   ));
   if ($result) {
-    error_log('MAILCOWAUTH: App auth for user ' . $post['username']);
+    error_log('MAILCOWAUTH: App auth for user ' . $post['username'] . " with service " . $post['service'] . " from IP " . $post['real_rip']);
     set_sasl_log($post['username'], $post['real_rip'], $post['service']);
   }
 }
@@ -94,9 +94,9 @@ if ($result === false){
   // Init Identity Provider
   $iam_provider = identity_provider('init');
   $iam_settings = identity_provider('get');
-  $result = user_login($post['username'], $post['password'], array('is_internal' => true));
+  $result = user_login($post['username'], $post['password'], array('is_internal' => true, 'service' => $post['service']));
   if ($result) {
-    error_log('MAILCOWAUTH: User auth for user ' . $post['username']);
+    error_log('MAILCOWAUTH: User auth for user ' . $post['username'] . " with service " . $post['service'] . " from IP " . $post['real_rip']);
     set_sasl_log($post['username'], $post['real_rip'], $post['service']);
   }
 }
@@ -105,7 +105,7 @@ if ($result) {
   http_response_code(200); // OK
   $return['success'] = true;
 } else {
-  error_log("MAILCOWAUTH: Login failed for user " . $post['username']);
+  error_log("MAILCOWAUTH: Login failed for user " . $post['username'] . " with service " . $post['service'] . " from IP " . $post['real_rip']);
   http_response_code(401); // Unauthorized
 }
 


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR fixes:
- https://github.com/mailcow/mailcow-dockerized/issues/6610

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

- Dovecot
- PHP-FPM

## Did you run tests?

### What did you tested?

I tested user logins with the primary password over protocols such as IMAP and SMTP, both with protocol access enabled and disabled. In all cases, the behavior was as expected.