### PR TITLE
scripts:  ipv6_controller improvement + fix modules handling

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -1,5 +1,26 @@
 #!/usr/bin/env bash
 
+# Ensure the script is run from the directory that contains a link of .env
+# Resolve the directory this script lives in for consistent behavior when invoked from elsewhere
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+
+# Ensure script is executed in the mailcow installation directory by checking for a .env symlink that points to mailcow.conf
+if [ ! -L "${PWD}/.env" ]; then
+  echo -e "\e[33mPlease run this script from the mailcow installation directory.\e[0m"
+  echo -e "  \e[36mcd /path/to/mailcow && ./generate_config.sh\e[0m"
+  exit 1
+fi
+
+# Verify the .env symlink points to a mailcow.conf file
+env_target="$(readlink -f "${PWD}/.env" 2>/dev/null || true)"
+if [ -z "$env_target" ] || [ "$(basename "$env_target")" != "mailcow.conf" ]; then
+  echo -e "\e[31mThe found .env symlink does not point to a mailcow.conf file.\e[0m"
+  echo -e "\e[33mPlease create a symbolic link .env -> mailcow.conf inside the mailcow directory and run this script there.\e[0m"
+  echo -e "\e[33mNote: 'ln -s mailcow.conf .env' will create the symlink even if mailcow.conf does not yet exist.\e[0m"
+  echo -e "  \e[36mcd /path/to/mailcow && ln -s mailcow.conf .env && ./generate_config.sh\e[0m"
+  exit 1
+fi
+
 # Load mailcow Generic Scripts
 source _modules/scripts/core.sh
 source _modules/scripts/ipv6_controller.sh

--- a/helper-scripts/_cold-standby.sh
+++ b/helper-scripts/_cold-standby.sh
@@ -293,7 +293,7 @@ if ! ssh -o StrictHostKeyChecking=no \
   -i "${REMOTE_SSH_KEY}" \
   ${REMOTE_SSH_HOST} \
   -p ${REMOTE_SSH_PORT} \
-  ${SCRIPT_DIR}/../update.sh -f --gc ; then
+  "cd \"${SCRIPT_DIR}/../\" && ./update.sh -f --gc" ; then
     >&2 echo -e "\e[31m[ERR]\e[0m - Could not cleanup old images on remote"
 fi
 

--- a/update.sh
+++ b/update.sh
@@ -3,6 +3,20 @@
 ############## Begin Function Section ##############
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MAILCOW_CONF="${SCRIPT_DIR}/mailcow.conf"
+
+# Ensure the script is run from the directory that contains mailcow.conf
+if [ ! -f "${PWD}/mailcow.conf" ]; then
+  if [ -f "${SCRIPT_DIR}/mailcow.conf" ]; then
+    echo -e "\e[33mPlease run this script directly from the mailcow installation directory:\e[0m"
+    echo -e "  \e[36mcd ${SCRIPT_DIR} && ./update.sh\e[0m"
+    exit 1
+  else
+    echo -e "\e[31mmailcow.conf not found in current directory or script directory (\e[36m${SCRIPT_DIR}\e[31m).\e[0m"
+    echo -e "\e[33mRun this script directly from your mailcow installation directory.\e[0m"
+    exit 1
+  fi
+fi
 BRANCH="$(cd "${SCRIPT_DIR}" && git rev-parse --abbrev-ref HEAD)"
 
 MODULE_DIR="${SCRIPT_DIR}/_modules"
@@ -26,8 +40,6 @@ if [ "$(id -u)" -ne "0" ]; then
   echo "You need to be root"
   exit 1
 fi
-
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Run pre-update-hook
 if [ -f "${SCRIPT_DIR}/pre_update_hook.sh" ]; then


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Description

This pull request introduces significant improvements to IPv6 detection and Docker configuration logic, as well as stricter requirements for running key scripts from the correct directory. The IPv6 detection is now more robust, distinguishing between administrative disablement, presence of default routes, and actual external connectivity. Docker configuration adapts to different Docker versions, only adding necessary settings for each version. Additionally, both `generate_config.sh` and `update.sh` now enforce that they are run from the proper installation directory, improving user guidance and preventing misconfiguration.

**IPv6 detection and configuration improvements:**

* Enhanced the `get_ipv6_support` function in `ipv6_controller.sh` to distinguish between administrative disablement, presence of default routes, link-local vs global addresses, and to actively probe external IPv6 connectivity without relying on DNS. This results in more accurate detection and messaging about IPv6 support.
* Updated the `configure_ipv6` function to automatically set or unset `ENABLE_IPV6` in `mailcow.conf` based on detected IPv6 support, and to skip Docker configuration if IPv6 is not available, with improved user messaging.

**Docker IPv6 configuration by version:**

* Modified `docker_daemon_edit` to only require and set `fixed-cidr-v6` for Docker versions below 28, and to only require `ip6tables` and `experimental` for versions below 27. The generated `daemon.json` now matches Docker's evolving requirements, avoiding unnecessary settings for newer versions. [[1]](diffhunk://#diff-83b497cdb901709fb2a8226796d622f0e4c2679eb3504fcabdacecc054f00728L42-R101) [[2]](diffhunk://#diff-83b497cdb901709fb2a8226796d622f0e4c2679eb3504fcabdacecc054f00728L63-R132) [[3]](diffhunk://#diff-83b497cdb901709fb2a8226796d622f0e4c2679eb3504fcabdacecc054f00728L100-R179) (Fixes #6721)
* Improved the key-value matching logic in `docker_daemon_edit` for more robust parsing of `daemon.json`.

**Script execution directory enforcement:**

* Added checks in `generate_config.sh` to ensure it is run from the mailcow installation directory, verifying that `.env` is a symlink to `mailcow.conf` and providing clear instructions if not.
* Added similar directory checks to `update.sh`, requiring it to be run from the directory containing `mailcow.conf`, with user-friendly error messages. [[1]](diffhunk://#diff-e14594f6bb9b29ac0146c04e78ae33e8e92f2f00709fefab97359dea31b94d11R6-R19) [[2]](diffhunk://#diff-e14594f6bb9b29ac0146c04e78ae33e8e92f2f00709fefab97359dea31b94d11L30-L31)

**Other improvements:**

* Fixed a bug in `configure_ipv6` where the check for a manual override now correctly uses `-n` to test for a non-empty variable.
* Fixed the remote update command in `_cold-standby.sh` to ensure the update script is run from the correct directory on the remote host.

###  Affected Containers

- none all script based

## Did you run tests?

### What did you tested?

Detection now works better with desired testing states.

### What were the final results? (Awaited, got)

mailcow detects more IPv6 scenarios and the scripts are now called more precicely. 