### PR TITLE
[Nginx] fix: Disable IPv6 support in Nginx configuration

### DIFF
--- a/data/conf/nginx/templates/nginx.conf.j2
+++ b/data/conf/nginx/templates/nginx.conf.j2
@@ -78,7 +78,7 @@ http {
         {%endif%}
         listen {{ HTTPS_PORT }}{% if NGINX_USE_PROXY_PROTOCOL %} proxy_protocol{%endif%} ssl;
 
-        {% if not DISABLE_IPv6 %}
+        {% if ENABLE_IPV6 %}
         {% if not HTTP_REDIRECT %}
         listen [::]:{{ HTTP_PORT }}{% if NGINX_USE_PROXY_PROTOCOL %} proxy_protocol{%endif%};
         {%endif%}
@@ -105,7 +105,7 @@ http {
         {%endif%}
         listen {{ HTTPS_PORT }}{% if NGINX_USE_PROXY_PROTOCOL %} proxy_protocol{%endif%} ssl;
 
-        {% if not DISABLE_IPv6 %}
+        {% if ENABLE_IPV6 %}
         {% if not HTTP_REDIRECT %}
         listen [::]:{{ HTTP_PORT }}{% if NGINX_USE_PROXY_PROTOCOL %} proxy_protocol{%endif%};
         {%endif%}
@@ -126,7 +126,7 @@ http {
     # rspamd dynmaps:
     server {
         listen 8081;
-        {% if not DISABLE_IPv6 %}
+        {% if ENABLE_IPV6 %}
         listen [::]:8081;
         {%endif%}
         index index.php index.html;
@@ -199,7 +199,7 @@ http {
         {%endif%}
         listen {{ HTTPS_PORT }}{% if NGINX_USE_PROXY_PROTOCOL %} proxy_protocol{%endif%} ssl;
 
-        {% if not DISABLE_IPv6 %}
+        {% if ENABLE_IPV6 %}
         {% if not HTTP_REDIRECT %}
         listen [::]:{{ HTTP_PORT }}{% if NGINX_USE_PROXY_PROTOCOL %} proxy_protocol{%endif%};
         {%endif%}


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
This PR renames the legacy `DISABLE_IPv6` template checks in `nginx.conf.j2` to  `ENABLE_IPV6`. 
Currently, this stops Mailcow from operating on systems without IPv6 support or where IPv6 is disabled!

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->
- nginx-mailcow
<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
Without this commit, `mailcowdockerized-nginx-mailcow` fails to start after upgrading to version 2025-09a and repeatedly crashes trying to use IPv6.

### What were the final results? (Awaited, got)

With the corrected template in place, `mailcowdockerized-nginx-mailcow` starts successfully and runs as expected.
<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->