### PR TITLE
[Web] Allow wildcard subdomains for MTA-STS

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -1107,11 +1107,21 @@ function user_get_alias_details($username) {
   }
   return $data;
 }
-function is_valid_domain_name($domain_name) {
+function is_valid_domain_name($domain_name, $options = array()) {
   if (empty($domain_name)) {
     return false;
   }
+
+  // Convert domain name to ASCII for validation
   $domain_name = idn_to_ascii($domain_name, 0, INTL_IDNA_VARIANT_UTS46);
+
+  // Remove '*.' if wildcard subdomains are allowed
+  if (isset($options['allow_wildcard']) &&
+      $options['allow_wildcard'] == true &&
+      strpos($domain_name, '*.') === 0) {
+    $domain_name = substr($domain_name, 2);
+  }
+
   return (preg_match("/^([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*$/i", $domain_name)
        && preg_match("/^.{1,253}$/", $domain_name)
        && preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*$/", $domain_name));

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -1446,7 +1446,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           }
           foreach ($mx as $index => $mx_domain) {
             $mx_domain = idn_to_ascii(strtolower(trim($mx_domain)), 0, INTL_IDNA_VARIANT_UTS46);
-            if (!is_valid_domain_name($mx_domain)) {
+            if (!is_valid_domain_name($mx_domain, array('allow_wildcard' => true))) {
               $_SESSION['return'][] = array(
                 'type' => 'danger',
                 'log' => array(__FUNCTION__, $_action, $_type, $_data, $_attr),
@@ -3897,7 +3897,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             foreach ($mx as $index => $mx_domain) {
               $mx_domain = idn_to_ascii(strtolower(trim($mx_domain)), 0, INTL_IDNA_VARIANT_UTS46);
               $invalid_mx = false;
-              if (!is_valid_domain_name($mx_domain)) {
+              if (!is_valid_domain_name($mx_domain, array('allow_wildcard' => true))) {
                 $invalid_mx = $mx_domain;
                 break;
               }


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR allows wildcard subdomains to be added as MX servers in the MTA-STS configuration.
Fixes:
- https://github.com/mailcow/mailcow-dockerized/issues/6720

###  Affected Containers

- PHP-FPM

## Did you run tests?

### What did you tested?

Patterns like `*.mailcow.tld` are now allowed as MX servers.