### PR TITLE
Relay quarantine

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -621,7 +621,7 @@ function hasMailboxObjectAccess($username, $role, $object) {
     return false;
   }
   if ($username == $object) {
-    return true; 
+    return true;
   }
   $stmt = $pdo->prepare("SELECT `domain` FROM `mailbox` WHERE `username` = :object");
   $stmt->execute(array(':object' => $object));

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -621,13 +621,18 @@ function hasMailboxObjectAccess($username, $role, $object) {
     return false;
   }
   if ($username == $object) {
-    return true;
+    return true; 
   }
   $stmt = $pdo->prepare("SELECT `domain` FROM `mailbox` WHERE `username` = :object");
   $stmt->execute(array(':object' => $object));
   $row = $stmt->fetch(PDO::FETCH_ASSOC);
   if (isset($row['domain']) && hasDomainAccess($username, $role, $row['domain'])) {
     return true;
+  } else {
+    $domain = substr(strrchr($object, "@"), 1);
+    if ( hasDomainAccess( $username, $role, $domain )) {
+      return true;
+    }
   }
   return false;
 }


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->

This PR enables saving the quarantine history(queue) for domains that are only relayed and have no local mailboxes. The admin or the domain admin can manage the quarantine and release / delete etc. messages.

This is an implementation of the enhancement request #5325 

As a side note, it fixes a typo in a SQL query in pipe.php (no change of funcionality there).

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

- rspamd (for metadata export)
- web (for the functions.inc.php) mods.

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?

Yes. Using it live.

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->

Queue comes up. The admin can do all operations. Also a domain admin can do all operation. 

### What were the final results? (Awaited, got)

It works as expected.

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->