### PR TITLE
Fixed wrong footer escaping for certain characters

### DIFF
--- a/data/web/inc/header.inc.php
+++ b/data/web/inc/header.inc.php
@@ -62,7 +62,11 @@ if ($app_links_processed){
   }
 }
 
-
+// Workaround to get text with <br> straight to twig.
+// Using "nl2br" doesn't work with Twig as it would escape everything by default.
+if (isset($UI_TEXTS["ui_footer"])) {
+  $UI_TEXTS["ui_footer"] = nl2br($UI_TEXTS["ui_footer"]);
+}
 
 $globalVariables = [
   'mailcow_hostname' => getenv('MAILCOW_HOSTNAME'),

--- a/data/web/js/build/013-mailcow.js
+++ b/data/web/js/build/013-mailcow.js
@@ -22,8 +22,8 @@ $(document).ready(function() {
     $.notify({message: msg},{z_index: 20000, delay: auto_hide, type: type,placement: {from: "bottom",align: "right"},animate: {enter: 'animated fadeInUp',exit: 'animated fadeOutDown'}});
   }
 
-  $(".generate_password").click(async function( event ) {   
-    try { 
+  $(".generate_password").click(async function( event ) {
+    try {
       var password_policy = await window.fetch("/api/v1/get/passwordpolicy", { method:'GET', cache:'no-cache' });
       var password_policy = await password_policy.json();
       random_passwd_length = password_policy.length;
@@ -48,7 +48,7 @@ $(document).ready(function() {
     })
   }
   $(".rot-enc").html(function(){
-    return str_rot13($(this).html())
+    return str_rot13($(this).text())
   });
   // https://stackoverflow.com/questions/4399005/implementing-jquerys-shake-effect-with-animate
   function shake(div,interval,distance,times) {
@@ -125,7 +125,7 @@ $(document).ready(function() {
         }
       });
   })();
-  
+
   // responsive tabs, scroll to opened tab
   $(document).on("shown.bs.collapse shown.bs.tab", function (e) {
 	  var target = $(e.target);

--- a/data/web/js/build/013-mailcow.js
+++ b/data/web/js/build/013-mailcow.js
@@ -48,7 +48,11 @@ $(document).ready(function() {
     })
   }
   $(".rot-enc").html(function(){
-    return str_rot13($(this).text())
+    footer_html = $(this).html();
+    footer_html = footer_html.replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+                             .replace(/&amp;/g, '&').replace(/&nzc;/g, '&')
+                             .replace(/&quot;/g, '"').replace(/&#x27;/g, "'");
+    return str_rot13(footer_html)
   });
   // https://stackoverflow.com/questions/4399005/implementing-jquerys-shake-effect-with-animate
   function shake(div,interval,distance,times) {


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Wrong escaping of certain characters done by JavaScript.
Closes and Fixes #6768

###  Affected Containers

none

## Did you run tests?

### What did you tested?

Before:
<img width="515" height="385" alt="image" src="https://github.com/user-attachments/assets/b5de5c2a-9281-41f6-bb9a-f94c75db22fc" />

After:
<img width="563" height="386" alt="image" src="https://github.com/user-attachments/assets/ba1e6605-92e8-4a15-829a-a2eac8948be5" />

### What were the final results? (Awaited, got)

See above. Correct/no escaping.