### PR TITLE
fix autodiscover when using ldap with attribute mapping templates

### DIFF
--- a/data/web/autodiscover.php
+++ b/data/web/autodiscover.php
@@ -7,6 +7,8 @@ if(file_exists('inc/vars.local.inc.php')) {
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.inc.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.auth.inc.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/sessions.inc.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.mailbox.inc.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.ratelimit.inc.php';
 $default_autodiscover_config = $autodiscover_config;
 $autodiscover_config = array_merge($default_autodiscover_config, $autodiscover_config);
 


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?
It fixes autodiscover when using LDAP with attribute mapping templates
Details: [Issue with Autodiscover in Mailcow when using LDAP with attribute mapping templates](https://community.mailcow.email/d/5153-issue-with-autodiscover-in-mailcow-when-using-ldap-authentication-in-outlook)

### Short Description
I hope I didn't mix the line numbers...
https://github.com/mailcow/mailcow-dockerized/blob/ef0f366d1cc9f60a6b17f92390616301b3475535/data/web/inc/functions.auth.inc.php#L682 was throwing ```Call to undefined function mailbox()``` and after fixing, I got ```Call to undefined function ratelimit()```

<!-- Please write a short description, what your PR does here. -->

###  Affected Containers
- php-fpm-mailcow

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?
Yes.

### What did you tested?
Autodiscover

<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)
It works ;)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->