### PR TITLE
Show app passwords for successful logins on user page

### DIFF
--- a/data/web/js/site/user.js
+++ b/data/web/js/site/user.js
@@ -105,10 +105,9 @@ jQuery(function($){
               $(".last-sasl-login").append(`
                 <li class="list-group-item d-flex justify-content-between align-items-start">
                   <div class="ms-2 me-auto d-flex flex-column">
-                    <div class="fw-bold">` + real_rip + `</div>
-                    <small class="fst-italic mt-2">` + service + ` ` + local_datetime + `</small>
+                    <div class="fw-bold">` + real_rip + ip_location + `</div>
+                    <small class="fst-italic mt-2">` + service + ` ` + local_datetime + `</small>` + app_password + `
                   </div>
-                  <span>` + ip_location + `</span>
                 </li>
               `);
             })

--- a/data/web/js/site/user.js
+++ b/data/web/js/site/user.js
@@ -97,7 +97,7 @@ jQuery(function($){
               var datetime = new Date(item.datetime.replace(/-/g, "/"));
               var local_datetime = datetime.toLocaleDateString(undefined, {year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", second: "2-digit"});
               var service = '<div class="badge bg-secondary">' + item.service.toUpperCase() + '</div>';
-              var app_password = item.app_password ? ' <a href="/edit/app-passwd/' + item.app_password + '"><i class="bi bi-app-indicator"></i> ' + escapeHtml(item.app_password_name || "App") + '</a>' : '';
+              var app_password = item.app_password ? ' <a href="/edit/app-passwd/' + item.app_password + '"><i class="bi bi-key"></i><span class="ms-2">' + escapeHtml(item.app_password_name || "App") + '</span></a>' : '';
               var real_rip = item.real_rip.startsWith("Web") ? item.real_rip : '<a href="https://bgp.tools/prefix/' + item.real_rip + '" target="_blank">' + item.real_rip + "</a>";
               var ip_location = item.location ? ' <span class="flag-icon flag-icon-' + item.location.toLowerCase() + '"></span>' : '';
               var ip_data = real_rip + ip_location + app_password;

--- a/data/web/js/site/user.js
+++ b/data/web/js/site/user.js
@@ -97,7 +97,7 @@ jQuery(function($){
               var datetime = new Date(item.datetime.replace(/-/g, "/"));
               var local_datetime = datetime.toLocaleDateString(undefined, {year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", second: "2-digit"});
               var service = '<div class="badge bg-secondary">' + item.service.toUpperCase() + '</div>';
-              var app_password = item.app_password ? ' <a href="/edit/app-passwd/' + item.app_password + '"><i class="bi bi-key"></i><span class="ms-1">' + escapeHtml(item.app_password_name || "App") + '</span></a>' : '';
+              var app_password = item.app_password ? ' <a href="/edit/app-passwd/' + item.app_password + '"><i class="bi bi-key-fill"></i><span class="ms-1">' + escapeHtml(item.app_password_name || "App") + '</span></a>' : '';
               var real_rip = item.real_rip.startsWith("Web") ? item.real_rip : '<a href="https://bgp.tools/prefix/' + item.real_rip + '" target="_blank">' + item.real_rip + "</a>";
               var ip_location = item.location ? ' <span class="flag-icon flag-icon-' + item.location.toLowerCase() + '"></span>' : '';
               var ip_data = real_rip + ip_location + app_password;

--- a/data/web/js/site/user.js
+++ b/data/web/js/site/user.js
@@ -105,7 +105,7 @@ jQuery(function($){
               $(".last-sasl-login").append(`
                 <li class="list-group-item d-flex justify-content-between align-items-start">
                   <div class="ms-2 me-auto d-flex flex-column">
-                    <div class="fw-bold">` + real_rip + ip_location + `</div>
+                    <div class="fw-bold">` + ip_location + real_rip + `</div>
                     <small class="fst-italic mt-2">` + service + ` ` + local_datetime + `</small>` + app_password + `
                   </div>
                 </li>

--- a/data/web/js/site/user.js
+++ b/data/web/js/site/user.js
@@ -97,7 +97,7 @@ jQuery(function($){
               var datetime = new Date(item.datetime.replace(/-/g, "/"));
               var local_datetime = datetime.toLocaleDateString(undefined, {year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", second: "2-digit"});
               var service = '<div class="badge bg-secondary">' + item.service.toUpperCase() + '</div>';
-              var app_password = item.app_password ? ' <a href="/edit/app-passwd/' + item.app_password + '"><i class="bi bi-key"></i><span class="ms-2">' + escapeHtml(item.app_password_name || "App") + '</span></a>' : '';
+              var app_password = item.app_password ? ' <a href="/edit/app-passwd/' + item.app_password + '"><i class="bi bi-key"></i><span class="ms-1">' + escapeHtml(item.app_password_name || "App") + '</span></a>' : '';
               var real_rip = item.real_rip.startsWith("Web") ? item.real_rip : '<a href="https://bgp.tools/prefix/' + item.real_rip + '" target="_blank">' + item.real_rip + "</a>";
               var ip_location = item.location ? ' <span class="flag-icon flag-icon-' + item.location.toLowerCase() + '"></span>' : '';
               var ip_data = real_rip + ip_location + app_password;


### PR DESCRIPTION
Closes #6745 

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

This PR (re)adds the app passwords on the successful logins section on the user page - this is done essentially in the same as before it was removed

It also changes the icon to a key (made more sense than the previous icon, which was an app but didn't really resemble it) and moves the country flag so it is displayed before the IP on the same line, to tidy the interface slightly

<img width="445" height="619" alt="image" src="https://github.com/user-attachments/assets/ae95632a-5399-46fa-be9e-0c3c203f22d1" />


###  Affected Containers

- php-fpm-mailcow

Although does not need rebuilding as the files are mounted in the compose file

## Did you run tests?

No code tests as UI change only

Manual testing - links correctly to relevant app password, and IP address flag continues to show correctly

### What did you tested?
N/A

### What were the final results? (Awaited, got)

N/A

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->