### PR TITLE
[Redis] Update to Redis 7.4.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
             - mysql
 
     redis-mailcow:
-      image: redis:7.4.2-alpine
+      image: redis:7.4.6-alpine
       entrypoint: ["/bin/sh","/redis-conf.sh"]
       volumes:
         - redis-vol-1:/data/


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR updates Redis to `7.4.6` to apply the latest patch for `CVE-2025-49844`

###  Affected Containers

- Redis
