### PR TITLE
[Web] Add password verification when setting recovery email

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -1006,11 +1006,26 @@ function edit_user_account($_data) {
     update_sogo_static_view();
   }
   // edit password recovery email
-  elseif (isset($pw_recovery_email)) {
+  elseif (!empty($password_old) && isset($pw_recovery_email)) {
     if (!isset($_SESSION['acl']['pw_reset']) || $_SESSION['acl']['pw_reset'] != "1" ) {
       $_SESSION['return'][] = array(
         'type' => 'danger',
         'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
+        'msg' => 'access_denied'
+      );
+      return false;
+    }
+
+    $stmt = $pdo->prepare("SELECT `password` FROM `mailbox`
+        WHERE `kind` NOT REGEXP 'location|thing|group'
+          AND `username` = :user AND authsource = 'mailcow'");
+    $stmt->execute(array(':user' => $username));
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!verify_hash($row['password'], $password_old)) {
+      $_SESSION['return'][] =  array(
+        'type' => 'danger',
+        'log' => array(__FUNCTION__, $_data_log),
         'msg' => 'access_denied'
       );
       return false;

--- a/data/web/templates/modals/user.twig
+++ b/data/web/templates/modals/user.twig
@@ -326,6 +326,12 @@
               <small class="text-muted">{{ lang.user.password_reset_info }}</small>
             </div>
           </div>
+          <div class="row mb-4">
+            <label class="control-label col-sm-3" for="user_old_pass">{{ lang.user.password_now }}</label>
+            <div class="col-sm-9">
+              <input type="password" class="form-control" name="user_old_pass" autocomplete="off" required>
+            </div>
+          </div>
           <div class="row">
             <div class="offset-sm-3 col-sm-9">
               <button class="btn btn-xs-lg d-block d-sm-inline btn-success" data-action="edit_selected" data-id="pw_recovery_change" data-item="null" data-api-url='edit/self' data-api-attr='{}' href="#">{{ lang.user.save }}</button>


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR adds password verification when setting recovery email.
Fixes:
- https://github.com/mailcow/mailcow-dockerized/issues/6802

###  Affected Containers

- PHPFPM
