### PR TITLE
Disable opcache-jit

### DIFF
--- a/data/conf/phpfpm/php-conf.d/opcache-recommended.ini
+++ b/data/conf/phpfpm/php-conf.d/opcache-recommended.ini
@@ -7,9 +7,10 @@ opcache.interned_strings_buffer=16
 opcache.max_accelerated_files=10000
 opcache.memory_consumption=128
 opcache.save_comments=1
-opcache.revalidate_freq=120
 opcache.validate_timestamps=0
 
 ; JIT
-opcache.jit=1255
-opcache.jit_buffer_size=8M
+; Disabled for now due to some PHP segmentation faults observed
+; in certain environments. Possibly some PHP or PHP extension bug.
+opcache.jit=disable
+opcache.jit_buffer_size=0


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

opcache-jit seems to cause segmentation-fault when accessing the aliases page, while e.g. the API still is able to create/delete aliases - see #6839. It was only caused on certain environments - the more aliases were present, the higher likely the crash was.

Crash like:
```text
Oct 16 17:22:17 mail-redacted kernel: php-fpm[2599813]: segfault at 7f1195acee ip 00005567fb1377c5 sp 00007fff05f96098 error 4 in php-fpm[5567fae00000+462000]
Oct 16 17:22:17 mail-redacted kernel: Code: 0f 85 bd 50 cf ff 48 8b 47 10 48 8b 57 18 48 83 c0 38 48 39 d0 48 89 47 10 48 0f 43 d0 48 8b 47 50 48 89 57 18 48 85 c0 74 0b <48> 8b 10 48 89 57 50 c3 0f 1f 00 be 06 00 00 00 e9 66 e4 ff ff 66
Oct 16 17:22:17 mail-redacted mailcowdockerized-nginx-mailcow-1[3372338]: 2025/10/16 17:22:17 [error] 20#20: *1149078 recv() failed (104: Connection reset by peer) while reading response header from upstream, client: <redacted-ip>, server: mail.redacted.tld, request: "GET /api/v1/get/alias/all?_=1760628136876 HTTP/2.0", upstream: "fastcgi://172.22.1.6:9002", host: "mail.redacted.tld", referrer: "https://mail.redacted.tld/"
Oct 16 17:22:17 mail-redacted mailcowdockerized-php-fpm-mailcow-1[3372338]: [16-Oct-2025 17:22:17] WARNING: [pool web-worker] child 110 exited on signal 11 (SIGSEGV) after 10.947140 seconds from start
```

The reason is unclear. Potentially a PHP core or PHP extensions bug, or some weird incompatibility with musl from Alpine.

This PR is disabling opcache.jit. Fixes #6839.

###  Affected Containers

phpfpm

## Did you run tests?

### What did you tested?

UI still working.

### What were the final results? (Awaited, got)

It does.