### PR TITLE
Remove deprecated 'X-XSS-Protection' header

### DIFF
--- a/data/conf/nginx/templates/sites-default.conf.j2
+++ b/data/conf/nginx/templates/sites-default.conf.j2
@@ -14,7 +14,6 @@ ssl_session_tickets off;
 
 add_header Strict-Transport-Security "max-age=15768000;";
 add_header X-Content-Type-Options nosniff;
-add_header X-XSS-Protection "1; mode=block";
 add_header X-Robots-Tag none;
 add_header X-Download-Options noopen;
 add_header X-Frame-Options "SAMEORIGIN" always;


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This removes the `X-XSS-Protection` header from nginx. This header is no longer supported in some browsers and potentially make secure websites insecure.

Also Nextcloud has decided to do the same (as per their [Nextcloud v32 release notes](https://docs.nextcloud.com/server/stable/admin_manual/release_notes/upgrade_to_32.html)):

>Setup checks do not check for the X-XSS-Protection response header anymore. It has been removed from Nextcloud’s .htaccess and you may want to adjust your webserver config to not serve it anymore. XSS filtering was supported only until Chromium 78 and similarly old browsers, but had been found to cause more issues, including attack vectors, than it solved. Nowadays, aside of not serving the header at all, the only generally recommended value is 0. More context can be found in the [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-xss-protection).

###  Affected Containers

nginx-mailcow

## Did you run tests?

### What did you tested?

Checking via `curl` if header is removed.

### What were the final results? (Awaited, got)

Header gone.