### PR TITLE
Disable PHP version via config, add new security.ini override

### DIFF
--- a/data/conf/phpfpm/php-conf.d/security.ini
+++ b/data/conf/phpfpm/php-conf.d/security.ini
@@ -1,2 +1,2 @@
 ; disable X-Powered-By header
-expose_php=Off
+expose_php = Off

--- a/data/conf/phpfpm/php-conf.d/security.ini
+++ b/data/conf/phpfpm/php-conf.d/security.ini
@@ -1,0 +1,2 @@
+; disable X-Powered-By header
+expose_php=Off

--- a/data/web/inc/prerequisites.inc.php
+++ b/data/web/inc/prerequisites.inc.php
@@ -26,8 +26,6 @@ if (file_exists($_SERVER['DOCUMENT_ROOT'] . '/inc/app_info.inc.php')) {
 unset($https_port);
 $autodiscover_config = array_merge($default_autodiscover_config, $autodiscover_config);
 
-header_remove("X-Powered-By");
-
 // Yubi OTP API
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/lib/Yubico.php';
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
 
     php-fpm-mailcow:
       image: ghcr.io/mailcow/phpfpm:1.94
-      command: "php-fpm -d date.timezone=${TZ} -d expose_php=0"
+      command: "php-fpm -d date.timezone=${TZ}"
       depends_on:
         - redis-mailcow
       volumes:
@@ -142,6 +142,7 @@ services:
         - ./data/conf/phpfpm/php-fpm.d/pools.conf:/usr/local/etc/php-fpm.d/z-pools.conf:Z
         - ./data/conf/phpfpm/php-conf.d/opcache-recommended.ini:/usr/local/etc/php/conf.d/opcache-recommended.ini:Z
         - ./data/conf/phpfpm/php-conf.d/upload.ini:/usr/local/etc/php/conf.d/upload.ini:Z
+        - ./data/conf/phpfpm/php-conf.d/security.ini:/usr/local/etc/php/conf.d/security.ini:Z
         - ./data/conf/phpfpm/php-conf.d/other.ini:/usr/local/etc/php/conf.d/zzz-other.ini:Z
         - ./data/conf/dovecot/global_sieve_before:/global_sieve/before:z
         - ./data/conf/dovecot/global_sieve_after:/global_sieve/after:z


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

- Create new `security.ini` override file (more options planned)
- Use `expose_php` (see [php docs](https://www.php.net/manual/en/ini.core.php#ini.expose-php) in above file to disable PHP version
- Remove `header_remove()` from PHP code

###  Affected Containers

php-fpm

## Did you run tests?

### What did you tested?

- `curl -I` to check if PHP version is indeed hidden (nginx is removing the header, but this change does this already on PHP side)

### What were the final results? (Awaited, got)

Working.