### PR TITLE
Hide nginx version in http context for all sites

### DIFF
--- a/data/conf/nginx/templates/nginx.conf.j2
+++ b/data/conf/nginx/templates/nginx.conf.j2
@@ -13,6 +13,7 @@ events {
 http {
     include /etc/nginx/mime.types;
     default_type  application/octet-stream;
+    server_tokens off;
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This simply adds `server_tokens off;` in the `http {}` context of nginx, which disables nginx version for all sites for any requests. There are some requests (mostly internal) where version is still visible. Just for consistency.

###  Affected Containers

nginx

## Did you run tests?

### What did you tested?

nginx version now hidden on all sites/requests:
```text
$ docker compose -f /opt/mailcow-dockerized/docker-compose.yml exec php-fpm-mailcow curl -I http://nginx | grep -i server
Server: nginx/1.29.1

$ docker compose -f /opt/mailcow-dockerized/docker-compose.yml exec php-fpm-mailcow curl -I http://nginx | grep -i server
Server: nginx
```

### What were the final results? (Awaited, got)

No nginx version present.