### PR TITLE
Support for PBKDF2-SHA512 hash algorithm in verify_hash() (FreeIPA compatibility) (issue 6646)

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -821,16 +821,20 @@ function verify_hash($hash, $password) {
 
         // 1st part: iteration count (integer)
         $iterations = intval($components[0]);
+        if ($iterations <= 0) return false;
+
         // 2nd part: salt (base64-encoded)
         $salt = $components[1];
         // 3rd part: hash (base64-encoded)
         $stored_hash_b64 = $components[2];
 
         // Decode salt and hash from base64
-        $salt_bin = base64_decode($salt);
-        $hash_bin = base64_decode($stored_hash_b64);
+        $salt_bin = base64_decode($salt, true);
+        $hash_bin = base64_decode($stored_hash_b64, true);
+        if ($salt_bin === false || $hash_bin === false) return false;
         // Get length of hash in bytes
         $hash_len = strlen($hash_bin);
+        if ($hash_len <= 0) return false;
 
         // Calculate PBKDF2-SHA512 hash for provided password
         $test_hash = hash_pbkdf2('sha512', $password, $salt_bin, $iterations, $hash_len, true);

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -834,7 +834,7 @@ function verify_hash($hash, $password) {
         if ($salt_bin === false || $hash_bin === false) return false;
         // Get length of hash in bytes
         $hash_len = strlen($hash_bin);
-        if ($hash_len <= 0) return false;
+        if ($hash_len === 0) return false;
 
         // Calculate PBKDF2-SHA512 hash for provided password
         $test_hash = hash_pbkdf2('sha512', $password, $salt_bin, $iterations, $hash_len, true);


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description
Add **PBKDF2-SHA512** support to `verify_hash()` so Mailcow can validate password hashes created by **FreeIPA (LDAP)** (see issue mailcow/mailcow-dockerized#6646).  
This change only extends the existing verification logic; no defaults are changed and no existing algorithms are removed.

### Affected Containers
- `php-fpm-mailcow` (PHP code path `data/web/inc/...` used by the web UI / API)

## Did you run tests?
Y
### What did you tested?
- Positive match: a known PBKDF2-SHA512 hash generated from a known password validates as **true**.
- Negative match: the same hash with a wrong password validates as **false**.
- Regression: existing supported algorithms still validate exactly as before.
- Error handling: malformed PBKDF2-SHA512 strings are rejected safely.

### What were the final results? (Awaited, got)
- **Awaited:** PBKDF2-SHA512 hashes produced by FreeIPA(LDAP) are accepted; non-matching passwords are rejected; no behavior change for other algorithms.
- **Got:** All checks above pass locally. No performance degradation was observed for existing paths; the new branch is only taken when the hash is of PBKDF2-SHA512 type.

---

**Closes:** mailcow/mailcow-dockerized#6646
