### PR TITLE
Fix: TFA authentication fails for internal requests (IMAP/SMTP)

### DIFF
--- a/data/conf/dovecot/auth/passwd-verify.lua
+++ b/data/conf/dovecot/auth/passwd-verify.lua
@@ -8,10 +8,16 @@ function auth_password_verify(request, password)
   local https = require "ssl.https"
   https.TIMEOUT = 30
 
+  -- Provide default value for real_rip if not set
+  local real_rip = request.real_rip
+  if real_rip == nil or real_rip == "" then
+    real_rip = "127.0.0.1"
+  end
+
   local req = {
     username = request.user,
     password = password,
-    real_rip = request.real_rip,
+    real_rip = real_rip,
     service = request.service
   }
   local req_json = json.encode(req)

--- a/data/web/inc/functions.auth.inc.php
+++ b/data/web/inc/functions.auth.inc.php
@@ -387,7 +387,7 @@ function user_login($user, $pass, $extra = null){
             'msg' => array('logged_in_as', $user)
           );
           return "pending";
-        } else if (!isset($authenticators['additional']) || !is_array($authenticators['additional']) || count($authenticators['additional']) == 0) {
+        } else {
           // no authenticators found, login successfull
           if (!$is_internal){
             unset($_SESSION['ldelay']);

--- a/tests/regression/tfa_internal_auth_test.php
+++ b/tests/regression/tfa_internal_auth_test.php
@@ -1,0 +1,149 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+/**
+ * Regression test for issue #6913 / PR #6914.
+ *
+ * Ensures that user_login() returns "user" for internal IMAP/SMTP requests
+ * when TFA is enabled (internal auth must bypass TFA), while UI logins with
+ * the same account and TFA still return "pending".
+ *
+ * Run via: php tests/regression/tfa_internal_auth_test.php
+ */
+
+$repoRoot = realpath(__DIR__ . '/../../');
+require_once $repoRoot . '/data/web/inc/functions.inc.php';
+require_once $repoRoot . '/data/web/inc/functions.auth.inc.php';
+
+$_SESSION = [];
+
+// Globals required by the auth helpers.
+$iam_provider = [];
+$iam_settings = [
+    'authsource' => 'mailcow',
+    'mailpassword_flow' => 0,
+];
+
+// In-memory SQLite database keeps the test isolated.
+/** @var PDO $pdo */
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+if (method_exists($pdo, 'sqliteCreateFunction')) {
+    $pdo->sqliteCreateFunction('REGEXP', function (?string $pattern, ?string $value): int {
+        if ($pattern === null || $value === null) {
+            return 0;
+        }
+        $delimiter = '#';
+        $escaped = str_replace($delimiter, '\\' . $delimiter, $pattern);
+        return preg_match($delimiter . $escaped . $delimiter . 'i', $value) === 1 ? 1 : 0;
+    }, 2);
+}
+
+$pdo->exec(<<<'SQL'
+CREATE TABLE domain (
+  domain TEXT PRIMARY KEY,
+  active INTEGER NOT NULL
+);
+SQL);
+
+$pdo->exec(<<<'SQL'
+CREATE TABLE mailbox (
+  username TEXT PRIMARY KEY,
+  domain TEXT NOT NULL,
+  password TEXT NOT NULL,
+  active INTEGER NOT NULL,
+  attributes TEXT NOT NULL,
+  authsource TEXT NOT NULL,
+  kind TEXT NOT NULL
+);
+SQL);
+
+$pdo->exec(<<<'SQL'
+CREATE TABLE tfa (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT NOT NULL,
+  key_id TEXT,
+  authmech TEXT NOT NULL,
+  secret TEXT,
+  active INTEGER NOT NULL
+);
+SQL);
+
+$pdo->prepare('INSERT INTO domain (domain, active) VALUES (:domain, :active)')
+    ->execute([':domain' => 'example.org', ':active' => 1]);
+
+$mailPassword = '{BLF-CRYPT}' . password_hash('Sup3rSecret!', PASSWORD_BCRYPT);
+$attributes = json_encode([
+    'force_pw_update' => 0,
+    'imap_access' => '1',
+    'smtp_access' => '1',
+]);
+$pdo->prepare('INSERT INTO mailbox (username, domain, password, active, attributes, authsource, kind)
+               VALUES (:username, :domain, :password, 1, :attributes, :authsource, "")')
+    ->execute([
+        ':username' => 'user@example.org',
+        ':domain' => 'example.org',
+        ':password' => $mailPassword,
+        ':attributes' => $attributes,
+        ':authsource' => 'mailcow',
+    ]);
+
+// Helper for deterministic assertions.
+function assertSameResult($expected, $actual, string $message): void
+{
+    if ($expected !== $actual) {
+        fwrite(STDERR, "Assertion failed: {$message} (expected '{$expected}', got '{$actual}')\n");
+        exit(1);
+    }
+    fwrite(STDOUT, "✅ {$message}\n");
+}
+
+function resetSession(): void
+{
+    global $_SESSION;
+    $_SESSION = [];
+}
+
+function seedTfaEntries(PDO $pdo, bool $enabled): void
+{
+    $pdo->exec('DELETE FROM tfa');
+    if ($enabled) {
+        $stmt = $pdo->prepare('INSERT INTO tfa (username, key_id, authmech, secret, active)
+                               VALUES (:username, :key_id, :authmech, :secret, 1)');
+        $stmt->execute([
+            ':username' => 'user@example.org',
+            ':key_id' => 'totp-1',
+            ':authmech' => 'totp',
+            ':secret' => 'ABC123',
+        ]);
+    }
+}
+
+function performLogin(bool $isInternal): string|false
+{
+    resetSession();
+    return user_login(
+        'user@example.org',
+        'Sup3rSecret!',
+        [
+            'is_internal' => $isInternal,
+            'service' => 'imap',
+        ]
+    );
+}
+
+seedTfaEntries($pdo, true);
+
+$result = performLogin(false);
+assertSameResult('pending', $result, 'External (UI) login with TFA requires pending state');
+
+$result = performLogin(true);
+assertSameResult('user', $result, 'Internal IMAP login with TFA bypasses interactive TFA');
+
+seedTfaEntries($pdo, false);
+$result = performLogin(true);
+assertSameResult('user', $result, 'Internal IMAP login without TFA continues to succeed');
+
+fwrite(STDOUT, "All regression checks passed.\n");


### PR DESCRIPTION
## Summary
Fixes two critical authentication bugs in mailcow 2025 that prevent IMAP/SMTP authentication for users with Two-Factor Authentication enabled.

Closes #6913

## Changes

### 1. Fix missing real_rip default value (Dovecot Lua)
**File:** `data/conf/dovecot/auth/passwd-verify.lua`

Added default value handling for `request.real_rip` to prevent HTTP 400 errors when the value is nil or empty.

**Before:**
```lua
local req = {
  username = request.user,
  password = password,
  real_rip = request.real_rip,  -- Could be nil
  service = request.service
}
```

**After:**
```lua
local real_rip = request.real_rip
if real_rip == nil or real_rip == "" then
  real_rip = "127.0.0.1"
end

local req = {
  username = request.user,
  password = password,
  real_rip = real_rip,  -- Always has a value
  service = request.service
}
```

### 2. Fix TFA logic with internal authentication
**File:** `data/web/inc/functions.auth.inc.php` (line 390)

Simplified the TFA condition to properly handle internal authentication requests (IMAP/SMTP).

**Before:**
```php
} else if (\!isset($authenticators['additional']) || \!is_array($authenticators['additional']) || count($authenticators['additional']) == 0) {
  return "user";
}
// Falls through when TFA exists AND is_internal=true
```

**After:**
```php
} else {
  return "user";
}
// Now catches both: no TFA OR internal requests
```

## Testing
Both fixes have been tested and verified on a live mailcow 2025 installation:

- ✅ IMAP authentication with TFA-enabled user: **SUCCESS**
- ✅ SMTP authentication with TFA-enabled user: **SUCCESS**
- ✅ SOGo webmail authentication: **Still works**
- ✅ TFA on web UI: **Still required as expected**
- ✅ Password scheme BLF-CRYPT (bcrypt): **Working correctly**

## Impact
- **Severity:** Critical - Prevents email client access for users with TFA
- **Affected versions:** mailcow 2025 (new HTTPS auth architecture)
- **Affected users:** Anyone with TFA/Yubikey/TOTP enabled
- **Containers affected:** dovecot-mailcow, php-fpm-mailcow, nginx-mailcow

## Checklist
- [x] Tested on live mailcow 2025 installation
- [x] Both IMAP and SMTP authentication verified
- [x] TFA still works for web UI as expected
- [x] No regressions in SOGo webmail authentication
- [x] Follows mailcow coding standards
- [x] Targets `staging` branch as per contribution guidelines
- [x] Related issue created and referenced (#6913)

## Additional Notes
These bugs only affect mailcow 2025 due to the new HTTPS-based authentication architecture introduced in this version. The legacy Lua database query approach in 2024 did not have these issues.