### PR TITLE
fix(api): add missing break in CORS switch block causing save to hang

### DIFF
--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -1992,6 +1992,7 @@ if (isset($_GET['query'])) {
         break;
         case "cors":
           process_edit_return(cors('edit', $attr));
+        break;
         case "identity-provider":
           process_edit_return(identity_provider('edit', $attr));
         break;


### PR DESCRIPTION
## Fix: Missing `break` in CORS settings case block

This PR fixes #6925.

### Summary
Saving API → CORS settings hangs indefinitely because the switch-case block handling CORS configuration in `json_api.php` is missing a `break` statement.  
This causes an unintended fallthrough into the next case, preventing a valid JSON response and leaving the UI stuck.

### Change
Added the missing `break;` after the CORS case in:

