### PR TITLE
pf-tlspol: upgrade to 1.8.22

### DIFF
--- a/data/Dockerfiles/postfix-tlspol/Dockerfile
+++ b/data/Dockerfiles/postfix-tlspol/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /src
 ENV CGO_ENABLED=0 \
     GO111MODULE=on \
 		NOOPT=1 \
-    VERSION=1.8.20
+    VERSION=1.8.22
 
 RUN git clone --branch v${VERSION} https://github.com/Zuplu/postfix-tlspol && \
     cd /src/postfix-tlspol && \

--- a/data/Dockerfiles/postfix-tlspol/Dockerfile
+++ b/data/Dockerfiles/postfix-tlspol/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /src
 ENV CGO_ENABLED=0 \
     GO111MODULE=on \
 		NOOPT=1 \
-    VERSION=1.8.14
+    VERSION=1.8.20
 
 RUN git clone --branch v${VERSION} https://github.com/Zuplu/postfix-tlspol && \
     cd /src/postfix-tlspol && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -382,7 +382,7 @@ services:
             - postfix
 
     postfix-tlspol-mailcow:
-      image: ghcr.io/mailcow/postfix-tlspol:1.0
+      image: ghcr.io/mailcow/postfix-tlspol:1.8.20
       depends_on:
         unbound-mailcow:
           condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -382,7 +382,7 @@ services:
             - postfix
 
     postfix-tlspol-mailcow:
-      image: ghcr.io/mailcow/postfix-tlspol:1.8.20
+      image: ghcr.io/mailcow/postfix-tlspol:1.8.22
       depends_on:
         unbound-mailcow:
           condition: service_healthy


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description


This pull request updates the `postfix-tlspol` component to use version 1.8.22 throughout the project. The main changes ensure that both the Docker build and the Docker Compose configuration use the new version.

Version update:

* Updated the `VERSION` environment variable in `data/Dockerfiles/postfix-tlspol/Dockerfile` from `1.8.14` to `1.8.22` to build the latest version of `postfix-tlspol`.
* Updated the `postfix-tlspol-mailcow` service image in `docker-compose.yml` to use version `1.8.22` instead of `1.0`, ensuring consistency with the Dockerfile.

###  Affected Containers

- postfix-tlspol

## Did you run tests?

### What did you tested?

The general mailing ability as well as the tlspolicy checks done by this container.

### What were the final results? (Awaited, got)

Works as expected