### PR TITLE
rspamd: upgrade to 3.14.1, trixie rebuild + bcc forwarded hosts fix

### DIFF
--- a/data/Dockerfiles/rspamd/Dockerfile
+++ b/data/Dockerfiles/rspamd/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 LABEL maintainer="The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG RSPAMD_VER=rspamd_3.13.2-1~8bf602278
-ARG CODENAME=bookworm
+ARG RSPAMD_VER=rspamd_3.14.1-1~46a758617
+ARG CODENAME=trixie
 ENV LC_ALL=C
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: ghcr.io/mailcow/rspamd:2.4
+      image: ghcr.io/mailcow/rspamd:3.14.1
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This pull request updates the Rspamd Docker image and refines the Lua configuration for improved handling of IP addresses (especially IPv6), recipient tagging, and BCC processing. The changes enhance compatibility, reliability, and logging, particularly for edge cases involving IPv6 and mail aliasing.

### Docker image and version updates

* Updated the Rspamd Docker image to use Debian Trixie and Rspamd version 3.14.1, both in the `Dockerfile` and the `docker-compose.yml`, ensuring the system runs on the latest stable versions. [[1]](diffhunk://#diff-db7d90c72bd1c1ef340fc04ebefce1968697d126cd504bffa06bd42eb5325a7dL1-R6) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L87-R87)

### IPv6 address handling improvements

* Added helper functions in `rspamd.local.lua` to generate all common IPv6 notations and CIDR variants, improving IP matching in Redis and ensuring that all possible representations of an IPv6 address are checked.

### Recipient tag ("Moo tag") logic enhancements

* Refactored the recipient tag handling in `TAG_MOO` to directly parse recipient addresses for tags, handle pre-result accept logic, improve logging, and ensure robust processing even when certain symbols are missing due to pre-results. [[1]](diffhunk://#diff-962f81f7c14809ad3812b5c0ef8ec713639635552426be4f4d61fb7be652c2ccR387) [[2]](diffhunk://#diff-962f81f7c14809ad3812b5c0ef8ec713639635552426be4f4d61fb7be652c2ccL221-L223) [[3]](diffhunk://#diff-962f81f7c14809ad3812b5c0ef8ec713639635552426be4f4d61fb7be652c2ccL234-R480) [[4]](diffhunk://#diff-962f81f7c14809ad3812b5c0ef8ec713639635552426be4f4d61fb7be652c2ccL275-R502) [[5]](diffhunk://#diff-962f81f7c14809ad3812b5c0ef8ec713639635552426be4f4d61fb7be652c2ccL302-R548)

### BCC logic improvements

* Improved BCC symbol handling to respect pre-result accept actions, added more detailed logging, and fixed sender address fallback logic to ensure BCC mails are sent reliably even when the original sender is unavailable. [[1]](diffhunk://#diff-962f81f7c14809ad3812b5c0ef8ec713639635552426be4f4d61fb7be652c2ccR558) [[2]](diffhunk://#diff-962f81f7c14809ad3812b5c0ef8ec713639635552426be4f4d61fb7be652c2ccR587-R593) [[3]](diffhunk://#diff-962f81f7c14809ad3812b5c0ef8ec713639635552426be4f4d61fb7be652c2ccL400-R657) [[4]](diffhunk://#diff-962f81f7c14809ad3812b5c0ef8ec713639635552426be4f4d61fb7be652c2ccL433-R670) [[5]](diffhunk://#diff-962f81f7c14809ad3812b5c0ef8ec713639635552426be4f4d61fb7be652c2ccL444-R681)

### Logging and reliability

* Enhanced logging throughout the Lua scripts for better traceability and debugging, and adjusted symbol return logic to avoid unnecessary logging of symbols in certain cases.

###  Affected Containers

- rspamd-mailcow

## Did you run tests?

### What did you tested?

1. Normal Spamfiltering without Forwarded Hosts
2. Enabled Forwarded Hosts with setup BCC Maps, previously not working
3. Enabled Forwarded Hosts with enabled Subadressing

### What were the final results? (Awaited, got)

In all cases the mails are now correctly handled, even if the spamfilter is disabled for a setup ip. Previously BCC and SubAdressings would be ignored as the IP was told to simply disable all rspamd modules, also BCC and Subadressing (Mootag).

With this Change it now work also if the IP is entered as forwarded ip.