### PR TITLE
ui: fix global filters ui tickbox reappearing

### DIFF
--- a/data/web/js/site/admin.js
+++ b/data/web/js/site/admin.js
@@ -54,7 +54,16 @@ jQuery(function($){
     $.get("/inc/ajax/show_rspamd_global_filters.php");
     $("#confirm_show_rspamd_global_filters").hide();
     $("#rspamd_global_filters").removeClass("d-none");
+    localStorage.setItem('rspamd_global_filters_confirmed', 'true');
   });
+  
+  $(document).ready(function() {
+    if (localStorage.getItem('rspamd_global_filters_confirmed') === 'true') {
+      $("#confirm_show_rspamd_global_filters").hide();
+      $("#rspamd_global_filters").removeClass("d-none");
+    }
+  });
+  
   $("#super_delete").click(function() { return confirm(lang.queue_ays); });
 
   $(".refresh_table").on('click', function(e) {


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This pull request improves the user experience for displaying the Rspamd global filters section in the admin interface. It remembers if a user has already confirmed viewing the filters and automatically shows the section on subsequent visits.

User experience enhancements:

* When the user confirms to show the Rspamd global filters, the confirmation is now saved in `localStorage` so the preference persists across page loads.
* On page load, if the user has previously confirmed, the confirmation dialog is hidden and the Rspamd global filters section is shown automatically.

**The local data will be purged when the user logs out automatically**

###  Affected Containers

none directly

## Did you run tests?

### What did you tested?

If the change has the affect (switching pages, change settings etc)

### What were the final results? (Awaited, got)

Tickbox only appears once each login session