### PR TITLE
Configurable displayName(s) - Fixes issue #6489

### DIFF
--- a/data/web/autoconfig.php
+++ b/data/web/autoconfig.php
@@ -29,8 +29,8 @@ header('Content-Type: application/xml');
 <clientConfig version="1.1">
     <emailProvider id="<?=$mailcow_hostname; ?>">
       <domain>%EMAILDOMAIN%</domain>
-      <displayName>A mailcow mail server</displayName>
-      <displayShortName>mail server</displayShortName>
+      <displayName><?=$autodiscover_config['displayName']; ?></displayName>
+      <displayShortName><?=$autodiscover_config['displayShortName']; ?></displayShortName>
 
       <incomingServer type="imap">
          <hostname><?=$autodiscover_config['imap']['server']; ?></hostname>

--- a/data/web/inc/vars.inc.php
+++ b/data/web/inc/vars.inc.php
@@ -33,6 +33,8 @@ if ($https_port === FALSE) {
 //$https_port = 1234;
 // Other settings =>
 $autodiscover_config = array(
+  'displayName' => 'A mailcow mail server',
+  'displayShortName' => 'mail server',
   // General autodiscover service type: "activesync" or "imap"
   // emClient uses autodiscover, but does not support ActiveSync. mailcow excludes emClient from ActiveSync.
   // With SOGo disabled, the type will always fallback to imap. CalDAV and CardDAV will be excluded, too.


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?
It includes the ability to configure `displayName` and `displayShortName` in the autoconfig endpoint.

### Short Description

<!-- Please write a short description, what your PR does here. -->

This fixes issue #6489, it adds the ability to configure `displayName` and `displayShortName` using `vars.local.inc.php`.

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

- nginx

## Did you run tests?
Yes

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
Tested if the override works and if empty it uses the default values.

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->
Results showed that the configuration of said variables works.

`vars.local.inc.php`
<img width="343" height="87" alt="Screenshot 2025-12-21 at 17 14 49" src="https://github.com/user-attachments/assets/10d2e923-de40-483a-b04a-df5d44087e71" />

Result of `/.well-known/autoconfig/mail/config-v1.1.xml`
<img width="499" height="112" alt="Screenshot 2025-12-21 at 17 12 55" src="https://github.com/user-attachments/assets/ebb0d004-fbb3-4054-9227-58a0fe1ee736" />

