### PR TITLE
[Rspamd] Do not try scanning eml with clamav when it's off

### DIFF
--- a/data/conf/rspamd/local.d/antivirus.conf
+++ b/data/conf/rspamd/local.d/antivirus.conf
@@ -1,3 +1,4 @@
+{% if env.SKIP_CLAMD == "n" %}
 clamav {
   # Scan whole message
   scan_mime_parts = false;
@@ -9,3 +10,4 @@ clamav {
   servers = "clamd:3310";
   max_size = 20971520;
 }
+{% endif %}

--- a/data/conf/rspamd/local.d/antivirus.conf
+++ b/data/conf/rspamd/local.d/antivirus.conf
@@ -1,4 +1,4 @@
-{% if env.SKIP_CLAMD == "n" %}
+{%- if env.SKIP_CLAMD == "n" or env.SKIP_CLAMD == "no" -%}
 clamav {
   # Scan whole message
   scan_mime_parts = false;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
         - REDISPASS=${REDISPASS}
         - SPAMHAUS_DQS_KEY=${SPAMHAUS_DQS_KEY:-}
+        - RSPAMD_SKIP_CLAMD=${SKIP_CLAMD:-n}
       volumes:
         - ./data/hooks/rspamd:/hooks:Z
         - ./data/conf/rspamd/custom/:/etc/rspamd/custom:z


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
Now when user disable clamav rspamd still doing attempts to scan email with clamav, this PR fixes this by dropping clamav settings when it doesn't enabled

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

- rspamd

## Did you run tests?

yes

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->
`docker compose exec rspamd-mailcow rspamadm configdump antivirus` shows nothing when clamav is `SKIP_CLAMD=y` and shows real config when `SKIP_CLAMD=n`

### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->