### PR TITLE
fix: Password for mobileconfig that conforms to password-complexity policy

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -205,6 +205,42 @@ function password_complexity($_action, $_data = null) {
     break;
   }
 }
+
+function password_generate(){
+  $password_complexity = password_complexity('get');
+  $min_length = max(16, intval($password_complexity['length']));
+
+  $lowercase = range('a', 'z');
+  $uppercase = range('A', 'Z');
+  $digits = range(0, 9);
+  $special_chars = str_split('!@#$%^&*()?=');
+
+  $password = [
+    $lowercase[random_int(0, count($lowercase) - 1)],
+    $uppercase[random_int(0, count($uppercase) - 1)],
+    $digits[random_int(0, count($digits) - 1)],
+    $special_chars[random_int(0, count($special_chars) - 1)],
+  ];
+
+  $all = array_merge($lowercase, $uppercase, $digits, $special_chars);
+
+  while (count($password) < $min_length) {
+    $password[] = $all[random_int(0, count($all) - 1)];
+  }
+
+  // Cryptographically secure shuffle using Fisher-Yates algorithm
+  $count = count($password);
+  for ($i = $count - 1; $i > 0; $i--) {
+    $j = random_int(0, $i);
+    $temp = $password[$i];
+    $password[$i] = $password[$j];
+    $password[$j] = $temp;
+  }
+
+  return implode('', $password);
+
+}
+
 function password_check($password1, $password2) {
   $password_complexity = password_complexity('get');
 

--- a/data/web/mobileconfig.php
+++ b/data/web/mobileconfig.php
@@ -34,15 +34,15 @@ catch(PDOException $e) {
 
 if (isset($_GET['only_email'])) {
   $onlyEmailAccount = true;
-  $description = 'IMAP';  
+  $description = 'IMAP';
 } else {
   $onlyEmailAccount = false;
-  $description = 'IMAP, CalDAV, CardDAV'; 
+  $description = 'IMAP, CalDAV, CardDAV';
 }
 if (isset($_GET['app_password'])) {
   $app_password = true;
   $description .= ' with application password';
-  
+
   if (strpos($_SERVER['HTTP_USER_AGENT'], 'iPad') !== FALSE)
       $platform = 'iPad';
   elseif (strpos($_SERVER['HTTP_USER_AGENT'], 'iPhone') !== FALSE)
@@ -51,8 +51,9 @@ if (isset($_GET['app_password'])) {
       $platform = 'Mac';
   else
       $platform = $_SERVER['HTTP_USER_AGENT'];
-  
-  $password = bin2hex(openssl_random_pseudo_bytes(16));
+
+  $password = password_generate();
+
   $attr = array(
       'app_name' => $platform,
       'app_passwd' => $password,


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

This PR fixes a bug, that caused Apple Connection Profiles not to be generated if a strong password-complexity policy was selected.

Fixes #6878 & #6981

Now the password is generated by a function password_generate() that creates sensible passwords compatible with the policy the user configured.

NOTE: I don't really like that this PR implements it's own password generation, but since the composer.json is still broken (and all libraries are prefetched, see also https://github.com/mailcow/mailcow-dockerized/pull/6652), I concluded that this would be the most sensible option.

###  Affected Containers

None, only Web

## Did you run tests?

### What did you test?

Generating a mobilconfig with a high complexity password policy.

### What were the final results? (Awaited, got)

The file was successfully generated and the password created was also saved to the database.