### PR TITLE
feat: allow preset of passwords via environment vars

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -186,13 +186,13 @@ DBNAME=mailcow
 DBUSER=mailcow
 
 # Please use long, random alphanumeric strings (A-Za-z0-9)
-DBPASS=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 2> /dev/null | head -c 28)
-DBROOT=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 2> /dev/null | head -c 28)
+DBPASS=${MAILCOW_DBPASS:-$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 2> /dev/null | head -c 28)}
+DBROOT=${MAILCOW_DBROOT:-$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 2> /dev/null | head -c 28)}
 
 # ------------------------------
 # REDIS configuration
 # ------------------------------
-REDISPASS=$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 2> /dev/null | head -c 28)
+REDISPASS=${MAILCOW_REDISPASS:-$(LC_ALL=C </dev/urandom tr -dc A-Za-z0-9 2> /dev/null | head -c 28)}
 
 # ------------------------------
 # HTTP/S Bindings


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

When the Environment variables `MAILCOW_DBPASS`, `MAILCOW_DBROOT` or `MAILCOW_REDISPASS` are present during run of `generate_config.sh` the corresponding `mailcow.conf` variables will be set to the values of these variables.

Default behavior (generation of passwords randomly) is still in place.

###  Affected Containers

- mysql-mailcow
- redis-mailcow
- php-fpm-mailcow
- sogo-mailcow
- dovecot-mailcow
- postfix-mailcow
- postfix-tlspol-mailcow
- acme-mailcow
- netfilter-mailcow
- watchdog-mailcow
- dockerapi-mailcow

## Did you run tests?

### What did you tested?

1. Fresh install without preset Environment variables:
```bash
generate_config.sh
```

2. Fresh install without preset Environment variables:
```bash
MAILCOW_DBPASS="insecure_dbpass" \
  MAILCOW_DBROOT="insecure_dbroot" \
  MAILCOW_REDISPASS="insecure_redispass" \
  && generate_config.sh
```

### What were the final results? (Awaited, got)

1. ad 1)
```bash
root@host:/opt/mailcow-dockerized# grep -E '^(DBPASS|DBROOT|REDISPASS)=' mailcow.conf
DBPASS=3uh0mXiWGpQYrZlKg5nRLR6eBfC1
DBROOT=CS02fuszcoEq1V4miJtKDlO6WF8h
REDISPASS=BlN7h8zP5iUGeI3T6KlEIL0vTWl7
```
✅  Random passwords generated by `generate_config.sh`

2. ad 2)
```bash
root@host:/opt/mailcow-dockerized# grep -E '^(DBPASS|DBROOT|REDISPASS)=' mailcow.conf
DBPASS=insecure_dbpass
DBROOT=insecure_dbroot
REDISPASS=insecure_redispass
```

✅  Preset passwords used as set.