### PR TITLE
Upgrade to postfix 3.10 with pqc support

### DIFF
--- a/data/Dockerfiles/postfix/Dockerfile
+++ b/data/Dockerfiles/postfix/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 LABEL maintainer="The Infrastructure Company GmbH <info@servercow.de>"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -339,7 +339,7 @@ services:
             - dovecot
 
     postfix-mailcow:
-      image: ghcr.io/mailcow/postfix:3.7.11-1
+      image: ghcr.io/mailcow/postfix:3.10.5
       depends_on:
         mysql-mailcow:
           condition: service_started


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Upgrades the postfix container base image to trixie-slim for postfix 3.10, which supports pqc.

Fixes #6354 

Requires some additional configuration in extra.cf ([docs](https://www.postfix.org/postconf.5.html#tls_eecdh_auto_curves)) "_to enable algorithm selection through OpenSSL_":

```
tls_eecdh_auto_curves =
tls_ffdhe_auto_groups =
```

Tested against my secondary backup cow using openssl:

```
$ openssl s_client -tls1_3 -groups X25519MLKEM768 -starttls smtp -connect mail.second.cow:25
[...]
No client certificate CA names sent
Peer signing digest: SHA256
Peer signature type: ecdsa_secp256r1_sha256
Negotiated TLS1.3 group: X25519MLKEM768
---
SSL handshake has read 3730 bytes and written 1539 bytes
Verification: OK
[...]
```

###  Affected Containers

- postfix

## Did you run tests?

### What did you test?

Tested on my secondary backup cow for a few hours to see if container is stable.

### What were the final results? (Awaited, got)

Working as expected, no issues in handshakes against pqc-supporting or "legacy" servers.