### PR TITLE
Document qitem endpoint in openapi.yaml for editing quarantine mails

### DIFF
--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -2454,6 +2454,90 @@ paths:
                   type: object
               type: object
       summary: Delete mails in Quarantine
+  /api/v1/edit/qitem:
+    post:
+      responses:
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "200":
+          content:
+            application/json:
+              examples:
+                release:
+                  value:
+                    - log:
+                        - quarantine
+                        - edit
+                        - id:
+                            - "33"
+                          action: release
+                      msg:
+                        - item_released
+                        - "33"
+                      type: success
+                learnham:
+                  value:
+                    - log:
+                        - quarantine
+                        - edit
+                        - id:
+                            - "34"
+                          action: learnham
+                      msg:
+                        - item_learned
+                        - "34"
+                      type: success
+              schema:
+                properties:
+                  log:
+                    description: contains request object
+                    items: {}
+                    type: array
+                  msg:
+                    items: {}
+                    type: array
+                  type:
+                    enum:
+                      - success
+                      - danger
+                      - error
+                    type: string
+                type: object
+          description: OK
+          headers: {}
+      tags:
+        - Quarantine
+      description: >-
+        Using this endpoint you can perform actions on quarantine items. It is possible to release
+        emails from quarantine into to the inbox, or learn them as ham to improve Rspamd filtering.
+        You must provide the quarantine item IDs. You can get the IDs using the GET method.      
+      operationId: Edit mails in Quarantine
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example:
+                items:
+                  - "33"
+                  - "34"
+                attr:
+                  action: release
+              properties:
+                items:
+                  description: contains list of quarantine item IDs to release or learn as ham
+                  type: object
+                attr:
+                  description: attributes for the action
+                  type: object
+                  properties:
+                    action:
+                      type: string
+                      enum:
+                        - release
+                        - learnham
+                      description: "release - return email to inbox; learnham - learn as ham to improve filtering"
+              type: object
+      summary: Edit mails in Quarantine
   /api/v1/delete/recipient_map:
     post:
       responses:


### PR DESCRIPTION
Added endpoint to edit quarantine items with actions to release or learn as ham. Functionality already existed but was undocumented.

<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Just documented the already existing edit/qitem API endpoint. It supports release and release + learn ham, but wasn't documented in the yaml. 

###  Affected Containers
N/A

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?

Tested by discovering the API calls worked, and then documented.

### What did you tested?

These API calls:

```
curl -X POST https://mail.mailcow.tld/api/v1/edit/qitem \
  -H "X-API-Key: api-key-string" \
  -H "Content-Type: application/json" \
  -d '{
    "items": [649, 650],
    "attr": {"action": "release"}
  }'
```

```
curl -X POST https://mail.mailcow.tld/api/v1/edit/qitem \
  -H "X-API-Key: api-key-string" \
  -H "Content-Type: application/json" \
  -d '{
  	"items": [700, 701], 
  	"attr": {"action": "learnham"}
  }'
```

<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)

They worked, so added to openapi.yaml.