### PR TITLE
Bump alpine version of netfilter

### DIFF
--- a/data/Dockerfiles/netfilter/Dockerfile
+++ b/data/Dockerfiles/netfilter/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.23
 
 LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 


### PR DESCRIPTION
Bump alpine image version from 3.21 to 3.23 in netfilter image.
Closes #7059
Closes #6904

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?
A version bump for the netfilter alpine base image from 3.21 to 3.23.

### Short Description
This PR fixes #7059

###  Affected Containers
- netfilter

## Did you run tests?
Yes

### What did you tested?
I used a docker-compose.override.yml with:
```
services:
  netfilter-mailcow:
    image: ghcr.io/jovobe/mailcow-dockerized-netfilter:1.64
```
To use the [image from my fork](https://github.com/jovobe/mailcow-dockerized/pkgs/container/mailcow-dockerized-netfilter) which included the changes of this PR.

### What were the final results? (Awaited, got)
The netfilter container did correctly find nftables backend and it was able to configure everything correctly. Here are the logs:
```
netfilter-mailcow-1  | # Warning: table ip filter is managed by iptables-nft, do not touch!
netfilter-mailcow-1  | # Warning: table ip nat is managed by iptables-nft, do not touch!
netfilter-mailcow-1  | # Warning: table ip6 filter is managed by iptables-nft, do not touch!
netfilter-mailcow-1  | # Warning: table ip6 nat is managed by iptables-nft, do not touch!
netfilter-mailcow-1  | # Warning: iptables-legacy tables present, use iptables-legacy-save to see them
netfilter-mailcow-1  | 2026-02-13 14:20:24 INFO: Using NFTables backend
netfilter-mailcow-1  | 2026-02-13 14:20:24 INFO: Clearing all bans
netfilter-mailcow-1  | 2026-02-13 14:20:24 INFO: Clear completed: ip
netfilter-mailcow-1  | 2026-02-13 14:20:25 INFO: Initializing mailcow netfilter chain
netfilter-mailcow-1  | 2026-02-13 14:20:25 INFO: MAILCOW ip chain created successfully.
netfilter-mailcow-1  | 2026-02-13 14:20:25 INFO: MAILCOW ip6 chain created successfully.
netfilter-mailcow-1  | 2026-02-13 14:20:25 INFO: Setting MAILCOW isolation
netfilter-mailcow-1  | 2026-02-13 14:20:25 INFO: Watching Redis channel F2B_CHANNEL
```