### PR TITLE
Add skip feature to mailcow admin password reset script

### DIFF
--- a/helper-scripts/mailcow-reset-admin.sh
+++ b/helper-scripts/mailcow-reset-admin.sh
@@ -7,6 +7,12 @@ if [[ -z ${DBUSER} ]] || [[ -z ${DBPASS} ]] || [[ -z ${DBNAME} ]]; then
 	exit 1
 fi
 
+SKIP_CONFIRM=false
+if [[ "${1:-}" == "-y" || "${1:-}" == "--yes" ]]; then
+    SKIP_CONFIRM=true
+    shift # prevent $1 from bleeding into head -c${1:-16} below
+fi
+
 echo -n "Checking MySQL service... "
 if [[ -z $(docker ps -qf name=mysql-mailcow) ]]; then
 	echo "failed"
@@ -15,8 +21,12 @@ if [[ -z $(docker ps -qf name=mysql-mailcow) ]]; then
 fi
 
 echo "OK"
-read -r -p "Are you sure you want to reset the mailcow administrator account? [y/N] " response
-response=${response,,}    # tolower
+if [[ "$SKIP_CONFIRM" == "true" ]]; then
+    response="yes"
+else
+    read -r -p "Are you sure you want to reset the mailcow administrator account? [y/N] " response
+    response=${response,,}
+fi
 if [[ "$response" =~ ^(yes|y)$ ]]; then
 	echo -e "\nWorking, please wait..."
   random=$(</dev/urandom tr -dc _A-Z-a-z-0-9 2> /dev/null | head -c${1:-16})


### PR DESCRIPTION
Added option to skip confirmation for resetting the mailcow admin account.

<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

I simply gave the possibility to skip confirmation in `helper-scripts/mailcow-reset-admin.sh` using a `-y` or `--yes` flag. This is useful for automation.

###  Affected Containers

No container is affected

## Did you run tests?

### What did you tested?

<!-- Please write shortly, what you've tested (which components etc.). -->

I tested the script both and without the flag I introduced.

**Without flag**

```
root@XXX:/opt/mailcow-dockerized# ./helper-scripts/mailcow-reset-admin.sh
Checking MySQL service... OK
Are you sure you want to reset the mailcow administrator account? [y/N] y

Working, please wait...

Reset credentials:
---
Username: admin
Password: 4awgpEghlxVis9xa
TFA: none
```

**With either `-y` or `--yes` flag**
```
root@XXX:/opt/mailcow-dockerized# ./helper-scripts/mailcow-reset-admin.sh -y
Checking MySQL service... OK

Working, please wait...

Reset credentials:
---
Username: admin
Password: _RlQ3Qh5i0VY-kAF
TFA: none
```

### What were the final results? (Awaited, got)

The script works as expected with or without the flag.
<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->