### PR TITLE
fix: show stopped and failed containers in dashboard and API

### DIFF
--- a/data/Dockerfiles/dockerapi/main.py
+++ b/data/Dockerfiles/dockerapi/main.py
@@ -110,12 +110,12 @@ async def get_container(container_id : str):
     return Response(content=json.dumps(res, indent=4), media_type="application/json")
 
 @app.get("/containers/json")
-async def get_containers():
+async def get_containers(all: bool = False):
   global dockerapi
 
   containers = {}
   try:
-    for container in (await dockerapi.async_docker_client.containers.list()):
+    for container in (await dockerapi.async_docker_client.containers.list(all=all)):
       container_info = await container.show()
       containers.update({container_info['Id']: container_info})
     return Response(content=json.dumps(containers, indent=4), media_type="application/json")

--- a/data/web/inc/functions.docker.inc.php
+++ b/data/web/inc/functions.docker.inc.php
@@ -63,7 +63,7 @@ function docker($action, $service_name = null, $attr1 = null, $attr2 = null, $ex
     break;
     case 'info':
       if (empty($service_name)) {
-        curl_setopt($curl, CURLOPT_URL, 'https://dockerapi:443/containers/json');
+        curl_setopt($curl, CURLOPT_URL, 'https://dockerapi:443/containers/json?all=true');
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($curl, CURLOPT_POST, 0);
         curl_setopt($curl, CURLOPT_TIMEOUT, $DOCKER_TIMEOUT);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -597,7 +597,7 @@ services:
             - watchdog
 
     dockerapi-mailcow:
-      image: ghcr.io/mailcow/dockerapi:2.11
+      image: ghcr.io/mailcow/dockerapi:2.11a
       security_opt:
         - label=disable
       restart: always


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?
This PR fixes a bug where stopped / crashed containers were not displayed in the dashboard and API.

### Short Description
The logic for displaying stopped container was already there. I just added in `data/Dockerfiles/dockerapi/main.py` a query parameter (`all`) that is optional on the route `/containers/json` of dockerapi. That way, the behavior from before isn't changed except when explicitly asked for on the dockerapi call.
When this parameter is true, all the containers, including stopped ones are returned and can be handled.
I then added in `data/web/inc/functions.docker.inc.php`, in the `info` case, in the dockerapi call, the `all` parameter.
The rest was already handled, as my tests confirmed.
I also edited the docker-compose.yml to change the dockerapi's version as required by the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md).

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

- dockerapi
- web

## Did you run tests?
I did some manual tests.

### What did you tested?
I tested the app and API with all containers running, and with a container stopped.
Here is a few screenshots : 

The dashboard with a container stopped :
<img width="1471" height="779" alt="2026-02-27-135648_hyprshot" src="https://github.com/user-attachments/assets/e12b4483-eeba-4a60-888a-daaece0fbb79" />

The dashboard with all containers running : 
<img width="1484" height="778" alt="2026-02-27-135619_hyprshot" src="https://github.com/user-attachments/assets/49df542c-80a8-43b1-a796-77bcbb3dce59" />

The API with a container stopped : 
<img width="381" height="256" alt="2026-02-27-141504_hyprshot" src="https://github.com/user-attachments/assets/72895752-e8b9-4861-a99a-76923c167b54" />

<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)
When a container is stopped, it's shown in the dashboard and API with the correct status.

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->