### PR TITLE
fix: route regular users through SOGo SSO authentication

### DIFF
--- a/data/web/inc/triggers.user.inc.php
+++ b/data/web/inc/triggers.user.inc.php
@@ -80,7 +80,7 @@ if (isset($_POST["verify_tfa_login"])) {
             intval($user_details['attributes']['force_pw_update']) != 1 &&
             getenv('SKIP_SOGO') != "y" &&
             !$is_dual) {
-          header("Location: /SOGo/so/");
+          header("Location: /sogo-auth.php?login=" . urlencode($_SESSION["mailcow_cc_username"]));
           die();
         } else {
           header("Location: /user");
@@ -146,7 +146,7 @@ if (isset($_POST["login_user"]) && isset($_POST["pass_user"])) {
         intval($user_details['attributes']['force_pw_update']) != 1 &&
         getenv('SKIP_SOGO') != "y" &&
         !$is_dual) {
-      header("Location: /SOGo/so/");
+      header("Location: /sogo-auth.php?login=" . urlencode($_SESSION["mailcow_cc_username"]));
       die();
     } else {
       header("Location: /user");

--- a/data/web/templates/user/tab-user-auth.twig
+++ b/data/web/templates/user/tab-user-auth.twig
@@ -24,7 +24,7 @@
                   {{ lang.user.open_webmail_sso }} <i class="bi bi-arrow-right"></i>
                 </a>
               {% else %}
-                <a href="/SOGo/so" role="button" class="btn btn-primary btn-lg btn-block btn-xs-lg w-100">
+                <a href="/sogo-auth.php?login={{ mailcow_cc_username }}" role="button" class="btn btn-primary btn-lg btn-block btn-xs-lg w-100">
                   {{ lang.user.open_webmail_sso }} <i class="bi bi-arrow-right"></i>
                 </a>
               {% endif %}


### PR DESCRIPTION
## Summary

Regular (non-dual-login) users get a **403 / Unauthorized** error from SOGo. This happens in two scenarios:

1. **On login:** The login handler in `triggers.user.inc.php` redirects regular users directly to `/SOGo/so/` (lines 83 and 149), bypassing the SSO authentication flow entirely.

2. **Clicking "Open webmail":** The template `tab-user-auth.twig` routes regular users to `/SOGo/so` directly instead of through `/sogo-auth.php?login=`.

Both paths fail because:
- `SOGoTrustProxyAuthentication=YES` disables SOGo's built-in login form
- The `_sogo_static_view` table has dummy password hashes (not real user passwords)
- Without the SSO flow, nginx sends empty proxy auth headers and SOGo returns 403

## Fix

**`data/web/inc/triggers.user.inc.php`** (2 locations):
```diff
-          header("Location: /SOGo/so/");
+          header("Location: /sogo-auth.php?login=" . urlencode($_SESSION["mailcow_cc_username"]));
```

**`data/web/templates/user/tab-user-auth.twig`** (1 location):
```diff
-                <a href="/SOGo/so" role="button" ...>
+                <a href="/sogo-auth.php?login={{ mailcow_cc_username }}" role="button" ...>
```

All three changes route through `/sogo-auth.php?login=` — the same SSO flow already used successfully for admin-as-user (dual_login) access. This properly sets `$_SESSION['sogo-sso-user-allowed']` and passes proxy auth headers to SOGo.

## Affected configurations

Any Mailcow instance where regular users access webmail. The bug is most visible when `ALLOW_ADMIN_EMAIL_LOGIN=n` (the recommended setting), but affects all regular user logins regardless of that setting.

## Testing

Verified end-to-end on a production Mailcow instance (SOGo 5.12.4-1):

**Before fix:**
- Regular user login → direct redirect to `/SOGo/so/` → 403 Unauthorized
- Regular user clicks "Open webmail" → `/SOGo/so` → 403 Unauthorized

**After fix:**
- Regular user login → `/sogo-auth.php?login=user@domain` → SSO session created → 302 → `/SOGo/so/user@domain/Mail/view` → **200 OK** (SOGo loads)
- Regular user clicks "Open webmail" → same SSO flow → **200 OK**

**Note:** After applying the template change, the Twig cache and PHP OPcache must be cleared:
```bash
# Clear Twig cache
docker compose exec php-fpm-mailcow sh -c 'rm -rf /web/templates/cache && mkdir -p /web/templates/cache'
# Restart php-fpm for OPcache
docker compose restart php-fpm-mailcow
```

Fixes #6442