### PR TITLE
[SOGo] Build SOGo from source with security patches

### DIFF
--- a/data/Dockerfiles/sogo/Dockerfile
+++ b/data/Dockerfiles/sogo/Dockerfile
@@ -1,47 +1,128 @@
-FROM debian:bookworm-slim
+# SOGo built from source to enable security patch application
+# Repository: https://github.com/Alinto/sogo
+# Version: SOGo-5.12.4
+#
+# Applied security patches:
+# - 16ab99e7cf8db2c30b211f0d5e338d7f9e3a9efb: XSS vulnerability in theme parameter
+#
+# To add new patches, modify SOGO_SECURITY_PATCHES ARG below with space-separated commit hashes
+
+FROM debian:bookworm
 
 LABEL maintainer="The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG DEBIAN_VERSION=bookworm
-ARG SOGO_DEBIAN_REPOSITORY=https://packagingv2.sogo.nu/sogo-nightly-debian/
+ARG SOGO_VERSION=SOGo-5.12.4
+ARG SOPE_VERSION=SOPE-5.12.4
+# Security patches to apply (space-separated commit hashes)
+ARG SOGO_SECURITY_PATCHES="16ab99e7cf8db2c30b211f0d5e338d7f9e3a9efb"
 # renovate: datasource=github-releases depName=tianon/gosu versioning=semver-coerced extractVersion=^(?<version>.*)$
 ARG GOSU_VERSION=1.19
 ENV LC_ALL=C
 
-# Prerequisites
-RUN echo "Building from repository $SOGO_DEBIAN_REPOSITORY" \
-  && apt-get update && apt-get install -y --no-install-recommends \
-  apt-transport-https \
-  ca-certificates \
-  gettext \
-  gnupg \
-  mariadb-client \
-  rsync \
-  supervisor \
-  syslog-ng \
-  syslog-ng-core \
-  syslog-ng-mod-redis \
-  dirmngr \
-  netcat-traditional \
-  psmisc \
-  wget \
-  patch \
+# Install all dependencies (build + runtime)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Build dependencies
+    git \
+    build-essential \
+    gobjc \
+    gnustep-make \
+    gnustep-base-runtime \
+    libgnustep-base-dev \
+    libxml2-dev \
+    libldap2-dev \
+    libssl-dev \
+    zlib1g-dev \
+    libpq-dev \
+    libmariadb-dev-compat \
+    libmemcached-dev \
+    libsodium-dev \
+    libcurl4-openssl-dev \
+    libzip-dev \
+    libytnef0-dev \
+    curl \
+    ca-certificates \
+    # Runtime dependencies
+    apt-transport-https \
+    gettext \
+    gnupg \
+    mariadb-client \
+    rsync \
+    supervisor \
+    syslog-ng \
+    syslog-ng-core \
+    syslog-ng-mod-redis \
+    dirmngr \
+    netcat-traditional \
+    psmisc \
+    wget \
+    patch \
+    libobjc4 \
+    libxml2 \
+    libldap-2.5-0 \
+    libssl3 \
+    zlib1g \
+    libmariadb3 \
+    libmemcached11 \
+    libsodium23 \
+    libcurl4 \
+    libzip4 \
+    libytnef0 \
   && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
   && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
   && chmod +x /usr/local/bin/gosu \
   && gosu nobody true \
-  && mkdir /usr/share/doc/sogo \
+  && mkdir -p /usr/share/doc/sogo \
   && touch /usr/share/doc/sogo/empty.sh \
-  && wget -O- https://keys.openpgp.org/vks/v1/by-fingerprint/74FFC6D72B925A34B5D356BDF8A27B36A6E2EAE9 | gpg --dearmor | apt-key add - \
-  && echo "deb [trusted=yes] ${SOGO_DEBIAN_REPOSITORY} ${DEBIAN_VERSION} main" > /etc/apt/sources.list.d/sogo.list \
-  && apt-get update && apt-get install -y --no-install-recommends \
-    sogo \
-    sogo-activesync \
   && apt-get autoclean \
   && rm -rf /var/lib/apt/lists/* \
   && touch /etc/default/locale
 
+# Build SOPE (SOGo's framework dependency)
+RUN git clone --depth 1 --branch ${SOPE_VERSION} https://github.com/Alinto/sope.git /tmp/sope \
+  && cd /tmp/sope \
+  && . /usr/share/GNUstep/Makefiles/GNUstep.sh \
+  && ./configure --prefix=/usr --enable-debug \
+  && make -j$(nproc) \
+  && make install \
+  && cd / \
+  && rm -rf /tmp/sope
+
+# Build SOGo with security patches
+RUN git clone --depth 1 --branch ${SOGO_VERSION} https://github.com/Alinto/sogo.git /tmp/sogo \
+  && cd /tmp/sogo \
+  && git config user.email "builder@mailcow.local" \
+  && git config user.name "SOGo Builder" \
+  && for patch in ${SOGO_SECURITY_PATCHES}; do \
+       echo "Applying security patch: ${patch}"; \
+       git fetch origin ${patch} && git cherry-pick ${patch}; \
+     done \
+  && . /usr/share/GNUstep/Makefiles/GNUstep.sh \
+  && ./configure --enable-debug \
+  && make \
+  && make install \
+  && cd / \
+  && rm -rf /tmp/sogo
+
+# Configure library paths
+RUN echo "/usr/lib64" > /etc/ld.so.conf.d/sogo.conf \
+  && echo "/usr/local/lib/sogo" >> /etc/ld.so.conf.d/sogo.conf \
+  && echo "/usr/local/lib/GNUstep/Frameworks/SOGo.framework/Versions/5/sogo" >> /etc/ld.so.conf.d/sogo.conf \
+  && ldconfig
+
+# Create sogo user and group
+RUN groupadd -r -g 999 sogo \
+  && useradd -r -u 999 -g sogo -d /var/lib/sogo -s /bin/bash -c "SOGo Daemon" sogo \
+  && mkdir -p /var/lib/sogo /var/run/sogo /var/log/sogo \
+  && chown -R sogo:sogo /var/lib/sogo /var/run/sogo /var/log/sogo
+
+# Create symlinks for SOGo binaries
+RUN ln -s /usr/local/sbin/sogod /usr/sbin/sogod \
+  && ln -s /usr/local/sbin/sogo-tool /usr/sbin/sogo-tool \
+  && ln -s /usr/local/sbin/sogo-ealarms-notify /usr/sbin/sogo-ealarms-notify \
+  && ln -s /usr/local/sbin/sogo-slapd-sockd /usr/sbin/sogo-slapd-sockd
+
+# Copy configuration files and scripts
 COPY ./bootstrap-sogo.sh /bootstrap-sogo.sh
 COPY syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 COPY syslog-ng-redis_slave.conf /etc/syslog-ng/syslog-ng-redis_slave.conf

--- a/data/Dockerfiles/sogo/Dockerfile
+++ b/data/Dockerfiles/sogo/Dockerfile
@@ -20,7 +20,7 @@ ARG SOGO_SECURITY_PATCHES="16ab99e7cf8db2c30b211f0d5e338d7f9e3a9efb"
 ARG GOSU_VERSION=1.19
 ENV LC_ALL=C
 
-# Install all dependencies (build + runtime)
+# Install dependencies, build SOPE and SOGo, then clean up (all in one layer to minimize image size)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # Build dependencies
     git \
@@ -68,28 +68,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcurl4 \
     libzip4 \
     libytnef0 \
+  # Download gosu
   && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
   && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
   && chmod +x /usr/local/bin/gosu \
   && gosu nobody true \
-  && mkdir -p /usr/share/doc/sogo \
-  && touch /usr/share/doc/sogo/empty.sh \
-  && apt-get autoclean \
-  && rm -rf /var/lib/apt/lists/* \
-  && touch /etc/default/locale
-
-# Build SOPE (SOGo's framework dependency)
-RUN git clone --depth 1 --branch ${SOPE_VERSION} https://github.com/Alinto/sope.git /tmp/sope \
+  # Build SOPE
+  && git clone --depth 1 --branch ${SOPE_VERSION} https://github.com/Alinto/sope.git /tmp/sope \
   && cd /tmp/sope \
+  && rm -rf .git \
   && . /usr/share/GNUstep/Makefiles/GNUstep.sh \
-  && ./configure --prefix=/usr --enable-debug \
+  && ./configure --prefix=/usr --disable-debug --disable-strip \
   && make -j$(nproc) \
   && make install \
   && cd / \
-  && rm -rf /tmp/sope
-
-# Build SOGo with security patches
-RUN git clone --depth 1 --branch ${SOGO_VERSION} https://github.com/Alinto/sogo.git /tmp/sogo \
+  && rm -rf /tmp/sope \
+  # Build SOGo with security patches
+  && git clone --depth 1 --branch ${SOGO_VERSION} https://github.com/Alinto/sogo.git /tmp/sogo \
   && cd /tmp/sogo \
   && git config user.email "builder@mailcow.local" \
   && git config user.name "SOGo Builder" \
@@ -97,12 +92,50 @@ RUN git clone --depth 1 --branch ${SOGO_VERSION} https://github.com/Alinto/sogo.
        echo "Applying security patch: ${patch}"; \
        git fetch origin ${patch} && git cherry-pick ${patch}; \
      done \
+  && rm -rf .git \
   && . /usr/share/GNUstep/Makefiles/GNUstep.sh \
-  && ./configure --enable-debug \
-  && make \
+  && ./configure --disable-debug --disable-strip \
+  && make -j$(nproc) \
   && make install \
   && cd / \
-  && rm -rf /tmp/sogo
+  && rm -rf /tmp/sogo \
+  # Strip binaries
+  && strip --strip-unneeded /usr/local/sbin/sogod 2>/dev/null || true \
+  && strip --strip-unneeded /usr/local/sbin/sogo-tool 2>/dev/null || true \
+  && strip --strip-unneeded /usr/local/sbin/sogo-ealarms-notify 2>/dev/null || true \
+  && strip --strip-unneeded /usr/local/sbin/sogo-slapd-sockd 2>/dev/null || true \
+  # Remove build dependencies and clean up
+  && apt-get purge -y --auto-remove \
+    git \
+    build-essential \
+    gobjc \
+    gnustep-make \
+    libgnustep-base-dev \
+    libxml2-dev \
+    libldap2-dev \
+    libssl-dev \
+    zlib1g-dev \
+    libpq-dev \
+    libmariadb-dev-compat \
+    libmemcached-dev \
+    libsodium-dev \
+    libcurl4-openssl-dev \
+    libzip-dev \
+    libytnef0-dev \
+    curl \
+  && apt-get autoremove -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /usr/share/doc/* \
+  && rm -rf /usr/share/man/* \
+  && rm -rf /var/cache/debconf/* \
+  && rm -rf /tmp/* \
+  && rm -rf /root/.cache \
+  && find /usr/local/lib -name '*.a' -delete \
+  && find /usr/lib -name '*.a' -delete \
+  && mkdir -p /usr/share/doc/sogo \
+  && touch /usr/share/doc/sogo/empty.sh \
+  && touch /etc/default/locale
 
 # Configure library paths
 RUN echo "/usr/lib64" > /etc/ld.so.conf.d/sogo.conf \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: ghcr.io/mailcow/sogo:5.12.4-1
+      image: ghcr.io/mailcow/sogo:5.12.4-2
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

This PR modifies the SOGo Docker image to build from source instead of using pre-compiled packages from Alinto's repository. The primary motivation is that Alinto does not include security patches in their official packages in a timely manner, leaving systems vulnerable to known security issues.

The implementation uses a source-based build with git cherry-pick support to apply critical security patches before official releases.

**Key changes:**
- Single-stage Dockerfile building
- Git cherry-pick mechanism for applying security patches to stable releases

**Benefits:**
- Apply security patches immediately without waiting for official packages
- Easy addition of future patches via `SOGO_SECURITY_PATCHES` ARG

###  Affected Containers

- sogo-mailcow

## Did you run tests?

### What did you tested?

- Docker image builds successfully from source
- SOGo daemon starts and runs properly
