### PR TITLE
[SOGo] Fix draft folder creation by adding /var/spool/sogo directory

### DIFF
--- a/data/Dockerfiles/sogo/Dockerfile
+++ b/data/Dockerfiles/sogo/Dockerfile
@@ -146,8 +146,8 @@ RUN echo "/usr/lib64" > /etc/ld.so.conf.d/sogo.conf \
 # Create sogo user and group
 RUN groupadd -r -g 999 sogo \
   && useradd -r -u 999 -g sogo -d /var/lib/sogo -s /bin/bash -c "SOGo Daemon" sogo \
-  && mkdir -p /var/lib/sogo /var/run/sogo /var/log/sogo \
-  && chown -R sogo:sogo /var/lib/sogo /var/run/sogo /var/log/sogo
+  && mkdir -p /var/lib/sogo /var/run/sogo /var/log/sogo /var/spool/sogo \
+  && chown -R sogo:sogo /var/lib/sogo /var/run/sogo /var/log/sogo /var/spool/sogo
 
 # Create symlinks for SOGo binaries
 RUN ln -s /usr/local/sbin/sogod /usr/sbin/sogod \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: ghcr.io/mailcow/sogo:5.12.5-1
+      image: ghcr.io/mailcow/sogo:5.12.5-2
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Fixes draft folder creation failures in SOGo by adding the missing `/var/spool/sogo` directory. 

After updating to the self-compiled SOGo build, users reported errors when trying to create draft messages: `could not create folder for draft: '/var/spool/sogo/name@domain.tld/newDraft...'`. The issue was caused by the `/var/spool/sogo` directory not being created during the image build process.

This PR adds `/var/spool/sogo` to the directory creation and ownership setup in the SOGo Dockerfile.

Fixes:
- #7105

###  Affected Containers

- sogo-mailcow
