### PR TITLE
[SOGo] Add ActiveSync support

### DIFF
--- a/data/Dockerfiles/sogo/Dockerfile
+++ b/data/Dockerfiles/sogo/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     build-essential \
     gobjc \
+    pkg-config \
     gnustep-make \
     gnustep-base-runtime \
     libgnustep-base-dev \
@@ -40,6 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcurl4-openssl-dev \
     libzip-dev \
     libytnef0-dev \
+    libwbxml2-dev \
     curl \
     ca-certificates \
     # Runtime dependencies
@@ -68,6 +70,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcurl4 \
     libzip4 \
     libytnef0 \
+    libwbxml2-1 \
   # Download gosu
   && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
   && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
@@ -97,6 +100,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && ./configure --disable-debug --disable-strip \
   && make -j$(nproc) \
   && make install \
+  && cd /tmp/sogo/ActiveSync \
+  && . /usr/share/GNUstep/Makefiles/GNUstep.sh \
+  && make -j$(nproc) install \
   && cd / \
   && rm -rf /tmp/sogo \
   # Strip binaries

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: ghcr.io/mailcow/sogo:5.12.5-2
+      image: ghcr.io/mailcow/sogo:5.12.5-3
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Adds Microsoft ActiveSync support to the self-compiled SOGo build. The ActiveSync module was not being built due to missing build dependencies (pkg-config and libwbxml2), causing mobile device synchronization via Exchange ActiveSync protocol to fail.

This fix ensures the ActiveSync.SOGo bundle is properly compiled and installed, enabling full ActiveSync protocol support

Fixes:
- #7110

###  Affected Containers

- sogo-mailcow

