### PR TITLE
Add SimpleLogin-compatible API for automated alias creation

### DIFF
--- a/data/conf/nginx/templates/sites-default.conf.j2
+++ b/data/conf/nginx/templates/sites-default.conf.j2
@@ -104,6 +104,10 @@ location ~ ^/api/v1/(.*)$ {
     try_files $uri $uri/ /json_api.php?query=$1&$args;
 }
 
+location ~ ^/api/v2/(.*)$ {
+    try_files $uri $uri/ /simplelogin.php?query=$1&$args;
+}
+
 location ~ ^/cache/(.*)$ {
     try_files $uri $uri/ /resource.php?file=$1;
 }

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -2131,6 +2131,86 @@ function admin_api($access, $action, $data = null) {
     'msg' => 'admin_api_modified'
   );
 }
+function user_api($action, $data = null) {
+  global $pdo;
+  if (!isset($_SESSION['mailcow_cc_role'])) {
+    return false;
+  }
+  if ($_SESSION['mailcow_cc_role'] == 'user') {
+    $username = $_SESSION['mailcow_cc_username'];
+  }
+  elseif ($_SESSION['mailcow_cc_role'] == 'admin' || $_SESSION['mailcow_cc_role'] == 'domainadmin') {
+    if (isset($data['username']) && filter_var($data['username'], FILTER_VALIDATE_EMAIL)) {
+      if (!hasMailboxObjectAccess($_SESSION['mailcow_cc_username'], $_SESSION['mailcow_cc_role'], $data['username'])) {
+        $_SESSION['return'][] = array(
+          'type' => 'danger',
+          'log' => array(__FUNCTION__, $action),
+          'msg' => 'access_denied'
+        );
+        return false;
+      }
+      $username = $data['username'];
+    }
+    else {
+      $_SESSION['return'][] = array(
+        'type' => 'danger',
+        'log' => array(__FUNCTION__, $action),
+        'msg' => 'access_denied'
+      );
+      return false;
+    }
+  }
+  else {
+    $_SESSION['return'][] = array(
+      'type' => 'danger',
+      'log' => array(__FUNCTION__, $action),
+      'msg' => 'access_denied'
+    );
+    return false;
+  }
+  switch ($action) {
+    case 'get':
+      $stmt = $pdo->prepare("SELECT * FROM `user_api_key` WHERE `username` = :username AND `active` = '1'");
+      $stmt->execute(array(':username' => $username));
+      return $stmt->fetch(PDO::FETCH_ASSOC);
+    break;
+    case 'generate':
+      $api_key = implode('-', array(
+        strtoupper(bin2hex(random_bytes(3))),
+        strtoupper(bin2hex(random_bytes(3))),
+        strtoupper(bin2hex(random_bytes(3))),
+        strtoupper(bin2hex(random_bytes(3))),
+        strtoupper(bin2hex(random_bytes(3)))
+      ));
+      $stmt = $pdo->prepare("SELECT `id` FROM `user_api_key` WHERE `username` = :username");
+      $stmt->execute(array(':username' => $username));
+      $existing = $stmt->fetch(PDO::FETCH_ASSOC);
+      if (empty($existing)) {
+        $stmt = $pdo->prepare("INSERT INTO `user_api_key` (`username`, `api_key`, `active`) VALUES (:username, :api_key, 1)");
+      }
+      else {
+        $stmt = $pdo->prepare("UPDATE `user_api_key` SET `api_key` = :api_key WHERE `username` = :username");
+      }
+      $stmt->execute(array(':username' => $username, ':api_key' => $api_key));
+      $_SESSION['return'][] = array(
+        'type' => 'success',
+        'log' => array(__FUNCTION__, $action),
+        'msg' => 'user_api_key_generated'
+      );
+      return $api_key;
+    break;
+    case 'delete':
+      $stmt = $pdo->prepare("DELETE FROM `user_api_key` WHERE `username` = :username");
+      $stmt->execute(array(':username' => $username));
+      $_SESSION['return'][] = array(
+        'type' => 'success',
+        'log' => array(__FUNCTION__, $action),
+        'msg' => 'user_api_key_deleted'
+      );
+      return true;
+    break;
+  }
+}
 function license($action, $data = null) {
   global $pdo;
   global $redis;

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -4,7 +4,7 @@ function init_db_schema()
   try {
     global $pdo;
 
-    $db_version = "19022026_1220";
+    $db_version = "10032026_1000";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));
@@ -1146,6 +1146,33 @@ function init_db_schema()
         "keys" => array(
           "primary" => array(
             "" => array("refresh_token")
+          )
+        ),
+        "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"
+      ),
+      "user_api_key" => array(
+        "cols" => array(
+          "id" => "INT NOT NULL AUTO_INCREMENT",
+          "username" => "VARCHAR(255) NOT NULL",
+          "api_key" => "VARCHAR(255) NOT NULL",
+          "created" => "DATETIME(0) NOT NULL DEFAULT NOW(0)",
+          "active" => "TINYINT(1) NOT NULL DEFAULT '1'"
+        ),
+        "keys" => array(
+          "primary" => array(
+            "" => array("id")
+          ),
+          "unique" => array(
+            "api_key" => array("api_key"),
+            "username" => array("username")
+          ),
+          "fkey" => array(
+            "fk_user_api_key_username" => array(
+              "col" => "username",
+              "ref" => "mailbox.username",
+              "delete" => "CASCADE",
+              "update" => "NO ACTION"
+            )
           )
         ),
         "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"

--- a/data/web/inc/sessions.inc.php
+++ b/data/web/inc/sessions.inc.php
@@ -93,6 +93,31 @@ if (!empty($_SERVER['HTTP_X_API_KEY'])) {
   }
 }
 
+// SimpleLogin-compatible user API key (Authorization: apikey <key>)
+if (!empty($_SERVER['HTTP_AUTHORIZATION']) && empty($_SERVER['HTTP_X_API_KEY'])) {
+  if (preg_match('/^apikey\s+(.+)$/i', $_SERVER['HTTP_AUTHORIZATION'], $auth_matches)) {
+    $user_api_key = preg_replace('/[^a-zA-Z0-9-]/', '', $auth_matches[1]);
+    $stmt = $pdo->prepare("SELECT `username` FROM `user_api_key` WHERE `api_key` = :api_key AND `active` = '1'");
+    $stmt->execute(array(':api_key' => $user_api_key));
+    $user_api_return = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!empty($user_api_return['username'])) {
+      $_SESSION['mailcow_cc_username'] = $user_api_return['username'];
+      $_SESSION['mailcow_cc_role'] = 'user';
+      $_SESSION['mailcow_cc_api'] = true;
+      $_SESSION['mailcow_cc_api_access'] = 'rw';
+    }
+    else {
+      $redis->publish("F2B_CHANNEL", "mailcow UI: Invalid user API key from " . $_SERVER['REMOTE_ADDR']);
+      http_response_code(401);
+      echo json_encode(array(
+        'error' => 'authentication failed',
+        'code' => 'UNAUTHORIZED',
+      ));
+      exit();
+    }
+  }
+}
+
 // Handle logouts
 if (isset($_POST["logout"])) {
   if (isset($_SESSION["dual-login"])) {

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -331,6 +331,9 @@ if (isset($_GET['query'])) {
         case "app-passwd":
           process_add_return(app_passwd('add', $attr));
         break;
+        case "user-api-key":
+          process_add_return(user_api('generate'));
+        break;
         case "mta-sts":
           process_add_return(mailbox('add', 'mta_sts', $attr));
         break;
@@ -557,6 +560,10 @@ if (isset($_GET['query'])) {
                 process_get_return($data);
               break;
             }
+          break;
+
+          case "user-api-key":
+            process_get_return(user_api('get'));
           break;
 
           case "mailq":
@@ -1731,6 +1738,9 @@ if (isset($_GET['query'])) {
         break;
         case "app-passwd":
           process_delete_return(app_passwd('delete', array('id' => $items)));
+        break;
+        case "user-api-key":
+          process_delete_return(user_api('delete'));
         break;
         case "relayhost":
           process_delete_return(relayhost('delete', array('id' => $items)));

--- a/data/web/lang/lang.en-gb.json
+++ b/data/web/lang/lang.en-gb.json
@@ -1421,7 +1421,20 @@
         "weeks": "weeks",
         "with_app_password": "with app password",
         "year": "year",
-        "years": "years"
+        "years": "years",
+        "copy": "Copy to clipboard",
+        "user_api_key": "User API Key",
+        "user_api_key_info": "The User API Key allows third-party tools like <a href=\"https://bitwarden.com\" target=\"_blank\">Bitwarden</a> or <a href=\"https://vaultwarden.rs\" target=\"_blank\">Vaultwarden</a> to automatically create email aliases using the <a href=\"https://simplelogin.io\" target=\"_blank\">SimpleLogin</a>-compatible API. Keep this key secret.",
+        "user_api_key_current": "Current API Key",
+        "user_api_key_none": "No API key generated yet.",
+        "user_api_key_generate": "Generate API Key",
+        "user_api_key_regenerate": "Regenerate API Key",
+        "user_api_key_delete": "Delete API Key",
+        "user_api_key_created": "Created",
+        "user_api_key_usage": "Usage",
+        "user_api_key_usage_info": "Use the following endpoints with your API key to manage aliases via the SimpleLogin-compatible API. Configure Bitwarden/Vaultwarden with this mailcow instance URL and your API key.",
+        "user_api_key_endpoint": "API Endpoints:",
+        "user_api_key_auth_header": "Authentication Header:"
     },
     "warning": {
         "cannot_delete_self": "Cannot delete logged in user",

--- a/data/web/simplelogin.php
+++ b/data/web/simplelogin.php
@@ -1,0 +1,215 @@
+<?php
+/*
+ * SimpleLogin-compatible API for mailcow
+ *
+ * Implements the SimpleLogin alias API, allowing third-party tools like
+ * Bitwarden and Vaultwarden to create email aliases automatically.
+ *
+ * Authentication: Authorization: apikey <YOUR_USER_API_KEY>
+ *
+ * Endpoints:
+ *   GET  /api/v2/alias/options     - Get available domains for alias creation
+ *   POST /api/v2/alias/random/new  - Create a new random permanent alias
+ */
+
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
+
+cors("set_headers");
+// Override CORS Allow-Headers to include Authorization for SimpleLogin API
+header('Access-Control-Allow-Headers: Accept, Content-Type, X-Api-Key, Authorization, Origin');
+header('Content-Type: application/json');
+error_reporting(0);
+
+// Block requests not intended for direct API use by checking the 'Sec-Fetch-Dest' header.
+if (isset($_SERVER['HTTP_SEC_FETCH_DEST']) && $_SERVER['HTTP_SEC_FETCH_DEST'] !== 'empty') {
+  header('HTTP/1.1 403 Forbidden');
+  exit;
+}
+
+// Only allow authenticated users (via user API key from sessions.inc.php)
+if (empty($_SESSION['mailcow_cc_username']) || $_SESSION['mailcow_cc_role'] !== 'user') {
+  http_response_code(401);
+  echo json_encode(array(
+    'error' => 'authentication failed',
+    'code' => 'UNAUTHORIZED',
+  ));
+  exit;
+}
+
+$username = $_SESSION['mailcow_cc_username'];
+$request_uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$method = $_SERVER['REQUEST_METHOD'];
+
+// Parse query from nginx rewrite: /simplelogin.php?query=alias/options
+$query = isset($_GET['query']) ? trim($_GET['query'], '/') : '';
+// Also support direct path detection
+if (empty($query)) {
+  // Try to extract from REQUEST_URI
+  if (preg_match('#/api/v2/(.+)$#', $request_uri, $m)) {
+    $query = $m[1];
+  }
+}
+
+// Route: GET /api/v2/alias/options
+if ($method === 'GET' && $query === 'alias/options') {
+  // Get user's available domains
+  $mailbox_details = mailbox('get', 'mailbox_details', $username);
+  $primary_domain = $mailbox_details['domain'] ?? '';
+
+  $alias_details = user_get_alias_details($username);
+  $alias_domains = $alias_details['alias_domains'] ?? array();
+
+  $all_domains = array_unique(array_filter(array_merge(array($primary_domain), $alias_domains)));
+  $suffixes = array();
+  foreach ($all_domains as $domain) {
+    $suffixes[] = array(
+      'suffix' => '@' . $domain,
+      'signed_suffix' => '@' . $domain,
+    );
+  }
+
+  echo json_encode(array(
+    'prefixes' => array(),
+    'suffixes' => $suffixes,
+    'can_create' => (isset($_SESSION['acl']['spam_alias']) && $_SESSION['acl']['spam_alias'] == '1'),
+  ));
+  exit;
+}
+
+// Route: POST /api/v2/alias/random/new
+if ($method === 'POST' && $query === 'alias/random/new') {
+  // Check ACL
+  if (!isset($_SESSION['acl']['spam_alias']) || $_SESSION['acl']['spam_alias'] != '1') {
+    http_response_code(403);
+    echo json_encode(array(
+      'error' => 'access denied',
+      'code' => 'FORBIDDEN',
+    ));
+    exit;
+  }
+
+  // Parse request body
+  $body = json_decode(file_get_contents('php://input'), true);
+  $note = isset($body['note']) ? htmlspecialchars(trim($body['note'])) : '';
+  $hostname = isset($_GET['hostname']) ? htmlspecialchars(trim($_GET['hostname'])) : '';
+
+  // Build description from note and/or hostname
+  $description = '';
+  if (!empty($note)) {
+    $description = $note;
+  }
+  elseif (!empty($hostname)) {
+    $description = $hostname;
+  }
+
+  // Determine domain to use
+  $mailbox_details = mailbox('get', 'mailbox_details', $username);
+  $primary_domain = $mailbox_details['domain'] ?? '';
+
+  $alias_details = user_get_alias_details($username);
+  $alias_domains = $alias_details['alias_domains'] ?? array();
+
+  $all_domains = array_unique(array_filter(array_merge(array($primary_domain), $alias_domains)));
+
+  if (empty($all_domains)) {
+    http_response_code(422);
+    echo json_encode(array(
+      'error' => 'no valid domain available',
+      'code' => 'UNPROCESSABLE_ENTITY',
+    ));
+    exit;
+  }
+
+  // Use the primary domain by default
+  $domain = $primary_domain;
+
+  // Create a permanent random alias via the existing mailbox function
+  $alias_data = array(
+    'username' => $username,
+    'domain' => $domain,
+    'description' => $description,
+    'permanent' => true,
+  );
+
+  $result = mailbox('add', 'time_limited_alias', $alias_data);
+
+  if ($result === false) {
+    http_response_code(500);
+    $return_msgs = isset($_SESSION['return']) ? $_SESSION['return'] : array();
+    $error_msg = 'failed to create alias';
+    foreach ($return_msgs as $msg) {
+      if ($msg['type'] === 'danger') {
+        $error_msg = is_array($msg['msg']) ? implode(': ', $msg['msg']) : $msg['msg'];
+        break;
+      }
+    }
+    echo json_encode(array(
+      'error' => $error_msg,
+      'code' => 'INTERNAL_SERVER_ERROR',
+    ));
+    exit;
+  }
+
+  // Retrieve the newly created alias
+  $aliases = mailbox('get', 'time_limited_aliases', $username);
+  $new_alias = null;
+  if (!empty($aliases)) {
+    // The newest alias will be the one with the most recent creation time matching our description
+    usort($aliases, function($a, $b) {
+      return strtotime($b['created']) - strtotime($a['created']);
+    });
+    foreach ($aliases as $alias) {
+      if (!empty($alias['permanent']) && ($description === '' || $alias['description'] === $description)) {
+        $new_alias = $alias;
+        break;
+      }
+    }
+    if ($new_alias === null) {
+      $new_alias = $aliases[0];
+    }
+  }
+
+  if ($new_alias === null) {
+    http_response_code(500);
+    echo json_encode(array(
+      'error' => 'alias created but could not be retrieved',
+      'code' => 'INTERNAL_SERVER_ERROR',
+    ));
+    exit;
+  }
+
+  $created_ts = strtotime($new_alias['created']);
+  $created_date = date('Y-m-d H:i:s', $created_ts);
+
+  http_response_code(201);
+  echo json_encode(array(
+    'id' => $new_alias['address'],
+    'email' => $new_alias['address'],
+    'creation_date' => $created_date,
+    'creation_timestamp' => $created_ts,
+    'nb_forward' => 0,
+    'nb_block' => 0,
+    'nb_reply' => 0,
+    'enabled' => true,
+    'note' => $new_alias['description'] ?: null,
+    'name' => null,
+    'support_pgp' => false,
+    'disable_pgp' => false,
+    'latest_activity' => null,
+    'pinned' => false,
+    'mailboxes' => array(
+      array(
+        'id' => 1,
+        'email' => $username,
+      )
+    ),
+  ));
+  exit;
+}
+
+// No matching route
+http_response_code(404);
+echo json_encode(array(
+  'error' => 'route not found',
+  'code' => 'NOT_FOUND',
+));

--- a/data/web/templates/user.twig
+++ b/data/web/templates/user.twig
@@ -27,6 +27,9 @@
     {% if acl.pushover == 1 %}
     <li class="nav-item" role="presentation"><button class="nav-link" role="tab" aria-selected="false" aria-controls="Pushover" role="tab" data-bs-toggle="tab" data-bs-target="#Pushover">Pushover API</button></li>
     {% endif %}
+    {% if acl.spam_alias == 1 %}
+    <li class="nav-item" role="presentation"><button class="nav-link" role="tab" aria-selected="false" aria-controls="UserApiKey" role="tab" data-bs-toggle="tab" data-bs-target="#UserApiKey">{{ lang.user.user_api_key }}</button></li>
+    {% endif %}
   </ul>
 
   <div class="row">
@@ -40,6 +43,7 @@
         {% if acl.syncjobs == 1 %}{% include 'user/Syncjobs.twig' %}{% endif %}
         {% if acl.app_passwds == 1 %}{% include 'user/AppPasswds.twig' %}{% endif %}
         {% if acl.pushover == 1 %}{% include 'user/Pushover.twig' %}{% endif %}
+        {% if acl.spam_alias == 1 %}{% include 'user/UserApiKey.twig' %}{% endif %}
       </div>
     </div>
   </div>

--- a/data/web/templates/user/UserApiKey.twig
+++ b/data/web/templates/user/UserApiKey.twig
@@ -1,0 +1,71 @@
+<div class="tab-pane fade" id="UserApiKey" role="tabpanel" aria-labelledby="UserApiKey">
+  <div class="card mb-4">
+    <div class="card-header d-flex fs-5">
+      <button class="btn d-md-none flex-grow-1 text-start" data-bs-target="#collapse-tab-UserApiKey" data-bs-toggle="collapse" aria-controls="collapse-tab-UserApiKey">
+        {{ lang.user.user_api_key }}
+      </button>
+      <span class="d-none d-md-block">{{ lang.user.user_api_key }}</span>
+    </div>
+    <div id="collapse-tab-UserApiKey" class="card-body collapse" data-bs-parent="#user-content">
+      <div class="row">
+        <div class="col-md-12">
+          <p>{{ lang.user.user_api_key_info|raw }}</p>
+        </div>
+      </div>
+      <div class="row mt-3">
+        <div class="col-md-12">
+          <legend>{{ lang.user.user_api_key_current }}</legend>
+          <hr>
+          {% if user_api_key_data and user_api_key_data.api_key %}
+            <div class="input-group mb-3" style="max-width:600px">
+              <input type="text" class="form-control font-monospace" id="user_api_key_display" value="{{ user_api_key_data.api_key }}" readonly>
+              <button class="btn btn-outline-secondary" type="button" onclick="navigator.clipboard.writeText(document.getElementById('user_api_key_display').value)" title="{{ lang.user.copy }}">
+                <i class="bi bi-clipboard"></i>
+              </button>
+            </div>
+            <p class="text-muted small">{{ lang.user.user_api_key_created }}: {{ user_api_key_data.created }}</p>
+          {% else %}
+            <p class="text-muted">{{ lang.user.user_api_key_none }}</p>
+          {% endif %}
+        </div>
+      </div>
+      <div class="row mt-3">
+        <div class="col-md-12">
+          <div class="btn-group">
+            <a href="#" class="btn btn-sm btn-success"
+              data-action="add_item"
+              data-api-url="add/user-api-key"
+              data-api-attr="{}">
+              <i class="bi bi-plus-lg"></i> {% if user_api_key_data and user_api_key_data.api_key %}{{ lang.user.user_api_key_regenerate }}{% else %}{{ lang.user.user_api_key_generate }}{% endif %}
+            </a>
+            {% if user_api_key_data and user_api_key_data.api_key %}
+            <a href="#" class="btn btn-sm btn-danger ms-2"
+              data-action="delete_selected"
+              data-id="user-api-key"
+              data-item="current"
+              data-api-url="delete/user-api-key">
+              <i class="bi bi-trash"></i> {{ lang.user.user_api_key_delete }}
+            </a>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+      <div class="row mt-4">
+        <div class="col-md-12">
+          <legend>{{ lang.user.user_api_key_usage }}</legend>
+          <hr>
+          <p>{{ lang.user.user_api_key_usage_info|raw }}</p>
+          <div class="mb-3">
+            <strong>{{ lang.user.user_api_key_endpoint }}</strong>
+            <code class="d-block mt-1">GET https://{{ mailcow_hostname }}/api/v2/alias/options</code>
+            <code class="d-block mt-1">POST https://{{ mailcow_hostname }}/api/v2/alias/random/new</code>
+          </div>
+          <div class="mb-3">
+            <strong>{{ lang.user.user_api_key_auth_header }}</strong>
+            <code class="d-block mt-1">Authorization: apikey YOUR_API_KEY</code>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/data/web/user.php
+++ b/data/web/user.php
@@ -73,6 +73,7 @@ $template_data = [
   'lang_user' => json_encode($lang['user']),
   'number_of_app_passwords' => $number_of_app_passwords,
   'lang_datatables' => json_encode($lang['datatables']),
+  'user_api_key_data' => user_api('get'),
 ];
 
 $js_minifier->add('/web/js/site/user.js');


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Adds a per-user API key system and SimpleLogin-compatible endpoints, enabling tools like Bitwarden and Vaultwarden to automatically create mailcow aliases using the SimpleLogin integration.

**New files:**
- `data/web/simplelogin.php` — SimpleLogin-compatible API handler
- `data/web/templates/user/UserApiKey.twig` — User panel tab for API key management

**Modified files:**
- `data/web/inc/init_db.inc.php` — new `user_api_key` table (FK → `mailbox`, CASCADE on delete)
- `data/web/inc/functions.inc.php` — new `user_api()` function (`generate` / `get` / `delete`)
- `data/web/inc/sessions.inc.php` — handles `Authorization: apikey <KEY>` header auth, separate from the global admin API key
- `data/web/json_api.php` — routes for `add/user-api-key`, `get/user-api-key`, `delete/user-api-key`
- `data/conf/nginx/templates/sites-default.conf.j2` — routes `/api/v2/(.*)` to `simplelogin.php`
- `data/web/templates/user.twig` — adds "User API Key" tab (shown when `spam_alias` ACL = 1)
- `data/web/user.php` — passes `user_api_key_data` to the Twig template
- `data/web/lang/lang.en-gb.json` — new translation keys

**SimpleLogin-Compatible Endpoints** (routed via nginx: `/api/v2/(.*)` → `simplelogin.php`):
```
GET  /api/v2/alias/options      # returns user's available domains as SimpleLogin suffixes
POST /api/v2/alias/random/new   # creates a permanent spamalias, returns full SimpleLogin alias object
```
Aliases created via this API are permanent (`permanent=1`) — they never expire, appropriate for password manager use.

**JSON API Routes for key management:**
- `POST /api/v1/add/user-api-key` — generate/regenerate key
- `GET  /api/v1/get/user-api-key` — retrieve current key
- `DELETE /api/v1/delete/user-api-key` — revoke key




###  Affected Containers

- nginx-mailcow
- php-fpm-mailcow
- mysql-mailcow (schema migration via `init_db.inc.php`)

## Did you run tests?

### What did you tested?

- PHP syntax on all 6 modified/new PHP files (`php -l`)
- JSON validity of all 31 language files
- API key generation format: 5 groups of 6 uppercase hex chars (`XXXXXX-XXXXXX-XXXXXX-XXXXXX-XXXXXX`), all pass the sanitization regex used in `sessions.inc.php`
- `Authorization: apikey <key>` header parsing (case-insensitive; rejects `Bearer`/`Basic` headers)
- `/api/v2/alias/options` response shape — `prefixes`, `suffixes` (each with `suffix` + `signed_suffix`), `can_create`
- `/api/v2/alias/random/new` response shape — all fields expected by Bitwarden (`id`, `email`, `creation_date`, `enabled`, `mailboxes`, etc.) at HTTP 201
- nginx routing patterns: `/api/v1/(.*)` unchanged, `/api/v2/(.*)` → `simplelogin.php`
- `user_api()` access control: `user` role resolves own username; `admin`/`domainadmin` role requires explicit username; all other roles get `access_denied`
- Full integration flow: key generation → auth header extraction → alias options → alias creation response
- DB schema structure: all columns, unique constraints, and FK definition verified
- Twig template balance: all `{% if %}`/`{% endif %}` pairs matched
- `acl.spam_alias` guard on all new UI elements and API checks

### What were the final results? (Awaited, got)

All tests passed as expected:
- PHP syntax: **No syntax errors** in all files
- All 31 language JSON files: **valid**
- Key generation: 10/10 keys match `^[A-F0-9]{6}-[A-F0-9]{6}-[A-F0-9]{6}-[A-F0-9]{6}-[A-F0-9]{6}$` and survive sanitization
- Auth header parsing: correct match/no-match for `apikey`, `Apikey`, `APIKEY` (matched) and `Bearer`, `Basic`, empty (not matched)
- API response shapes: match SimpleLogin spec (Bitwarden-compatible)
- Routing: 6/6 route patterns correct
- Access control: 6/6 role/action combinations produced expected outcome
- UI renders correctly in both states (no key / key exists)

Fixes #6249