### PR TITLE
Fix theme localStorage collision with rspamd UI

### DIFF
--- a/data/web/js/build/013-mailcow.js
+++ b/data/web/js/build/013-mailcow.js
@@ -345,7 +345,7 @@ $(document).ready(function() {
       $('.main-logo-dark').addClass('d-none');
       if ($('#rspamd_logo').length) $('#rspamd_logo').attr('src', '/img/rspamd_logo_dark.png');
       if ($('#rspamd_logo_sm').length) $('#rspamd_logo_sm').attr('src', '/img/rspamd_logo_dark.png');
-      localStorage.setItem('theme', 'light');
+      localStorage.setItem('mailcow_theme', 'light');
     }else{
       $('head').append('<link id="dark-mode-theme" rel="stylesheet" type="text/css" href="/css/themes/mailcow-darkmode.css">');
       $('#dark-mode-toggle').prop('checked', true);
@@ -353,7 +353,7 @@ $(document).ready(function() {
       $('.main-logo-dark').removeClass('d-none');
       if ($('#rspamd_logo').length) $('#rspamd_logo').attr('src', '/img/rspamd_logo_light.png');
       if ($('#rspamd_logo_sm').length) $('#rspamd_logo_sm').attr('src', '/img/rspamd_logo_light.png');
-      localStorage.setItem('theme', 'dark');
+      localStorage.setItem('mailcow_theme', 'dark');
     }
   }
 

--- a/data/web/js/site/index.js
+++ b/data/web/js/site/index.js
@@ -1,5 +1,6 @@
 $(document).ready(function() {
-  var theme = localStorage.getItem("theme");
-  localStorage.clear();
-  localStorage.setItem("theme", theme);
+  var theme = localStorage.getItem("mailcow_theme");
+  if (theme !== null) {
+    localStorage.setItem("mailcow_theme", theme);
+  }
 });

--- a/data/web/templates/base.twig
+++ b/data/web/templates/base.twig
@@ -11,8 +11,8 @@
   <link rel="stylesheet" href="{{ css_path }}">
   <script>
     // check if darkmode is preferred by OS or set by localStorage
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches && localStorage.getItem("theme") !== "light" ||
-        localStorage.getItem("theme") === "dark") {
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches && localStorage.getItem("mailcow_theme") !== "light" ||
+        localStorage.getItem("mailcow_theme") === "dark") {
       var head  = document.getElementsByTagName('head')[0];
       var link  = document.createElement('link');
       link.id   = 'dark-mode-theme';


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?
Fixes #7083

Fix theme preference collision between mailcow admin UI (/admin) and rspamd UI (/rspamd).

Both used the same localStorage key "theme". 
Because both run on the same origin, changing the theme in one UI overwrote the other.

This PR introduces a separate key "mailcow_theme" for the mailcow UI and removes localStorage.clear().

### Short Description

Fix theme collision between mailcow UI and rspamd UI.

###  Affected Containers

- nginx-mailcow

## Did you run tests?

### What did you tested?

Manual testing only.

### What were the final results? (Awaited, got)
Awaited: mailcow ui / rspamd ui keep independent themes.
Got: Themes no longer overwrite each other.