### PR TITLE
[Web] Fix LDAP/Keycloak login TypeError - missing JSON decode for attributes

### DIFF
--- a/data/web/inc/functions.auth.inc.php
+++ b/data/web/inc/functions.auth.inc.php
@@ -287,6 +287,8 @@ function user_login($user, $pass, $extra = null){
             return false;
           }
 
+          $row['attributes'] = json_decode($row['attributes'], true);
+
           // check for tfa authenticators
           $authenticators = get_tfa($user);
           if (isset($authenticators['additional']) && is_array($authenticators['additional']) && count($authenticators['additional']) > 0 && !$is_internal) {
@@ -342,6 +344,8 @@ function user_login($user, $pass, $extra = null){
         if (empty($row)) {
           return false;
         }
+
+        $row['attributes'] = json_decode($row['attributes'], true);
 
         // check for tfa authenticators
         $authenticators = get_tfa($user);


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Fixes a critical TypeError that prevented LDAP and Keycloak users from logging in after PR #7077 was merged. The issue was caused by missing `json_decode()` calls when accessing user attributes after re-fetching the user row from the database.

Fixes:
- #7115

###  Affected Containers

- php-fpm-mailcow
