### PR TITLE
[ACME] Skip autodiscover/mta-sts subdomains covered by wildcard certificates

### DIFF
--- a/data/Dockerfiles/acme/acme.sh
+++ b/data/Dockerfiles/acme/acme.sh
@@ -253,10 +253,20 @@ while true; do
     unset VALIDATED_CONFIG_DOMAINS_SUBDOMAINS
     declare -a VALIDATED_CONFIG_DOMAINS_SUBDOMAINS
     for SUBDOMAIN in "${ADDITIONAL_WC_ARR[@]}"; do
-      if [[  "${SUBDOMAIN}.${SQL_DOMAIN}" != "${MAILCOW_HOSTNAME}" ]]; then
-        if check_domain "${SUBDOMAIN}.${SQL_DOMAIN}"; then
-          VALIDATED_CONFIG_DOMAINS_SUBDOMAINS+=("${SUBDOMAIN}.${SQL_DOMAIN}")
-        fi
+      FULL_SUBDOMAIN="${SUBDOMAIN}.${SQL_DOMAIN}"
+
+      # Skip if subdomain matches MAILCOW_HOSTNAME
+      if [[ "${FULL_SUBDOMAIN}" == "${MAILCOW_HOSTNAME}" ]]; then
+        continue
+      fi
+      # Skip if subdomain is covered by a wildcard in ADDITIONAL_SAN
+      if is_covered_by_wildcard "${FULL_SUBDOMAIN}"; then
+        log_f "Subdomain '${FULL_SUBDOMAIN}' is covered by wildcard - skipping explicit subdomain"
+        continue
+      fi
+      # Validate and add subdomain
+      if check_domain "${FULL_SUBDOMAIN}"; then
+        VALIDATED_CONFIG_DOMAINS_SUBDOMAINS+=("${FULL_SUBDOMAIN}")
       fi
     done
     VALIDATED_CONFIG_DOMAINS+=("${VALIDATED_CONFIG_DOMAINS_SUBDOMAINS[*]}")
@@ -273,7 +283,10 @@ while true; do
         fi
         # Only add mta-sts subdomain for alias domains
         if [[ "mta-sts.${alias_domain}" != "${MAILCOW_HOSTNAME}" ]]; then
-          if check_domain "mta-sts.${alias_domain}"; then
+          # Skip if mta-sts subdomain is covered by a wildcard
+          if is_covered_by_wildcard "mta-sts.${alias_domain}"; then
+            log_f "Alias domain mta-sts subdomain 'mta-sts.${alias_domain}' is covered by wildcard - skipping"
+          elif check_domain "mta-sts.${alias_domain}"; then
             VALIDATED_CONFIG_DOMAINS+=("mta-sts.${alias_domain}")
           fi
         fi

--- a/data/Dockerfiles/acme/functions.sh
+++ b/data/Dockerfiles/acme/functions.sh
@@ -135,3 +135,25 @@ verify_challenge_path(){
     return 1
   fi
 }
+
+# Check if a domain is covered by a wildcard in ADDITIONAL_SAN
+# Usage: is_covered_by_wildcard "subdomain.example.com"
+# Returns: 0 if covered, 1 if not covered
+is_covered_by_wildcard() {
+  local DOMAIN=$1
+
+  # Return early if no ADDITIONAL_SAN is set
+  if [[ -z ${ADDITIONAL_SAN} ]]; then
+    return 1
+  fi
+
+  # Extract parent domain (e.g., mail.example.com -> example.com)
+  local PARENT_DOMAIN=$(echo ${DOMAIN} | cut -d. -f2-)
+
+  # Check if ADDITIONAL_SAN contains a wildcard for this parent domain
+  if [[ "${ADDITIONAL_SAN}" == *"*.${PARENT_DOMAIN}"* ]]; then
+    return 0  # Covered by wildcard
+  fi
+
+  return 1  # Not covered
+}


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR extends the wildcard certificate fix from PR #7124 to all auto-generated subdomains (autodiscover, autoconfig, mta-sts).

**Problem:** When `ADDITIONAL_SAN` contains a wildcard certificate (e.g., `*.example.com`) and `AUTODISCOVER_SAN=y`, mailcow automatically adds `autodiscover.example.com`, `autoconfig.example.com`, and `mta-sts.example.com` to the certificate request. These are redundant with the wildcard and Let's Encrypt rejects the request with: *"Domain name 'X' is redundant with a wildcard domain"*.

**Solution:** Before adding these subdomains to the certificate request, check if they are already covered by a wildcard in `ADDITIONAL_SAN`. If yes, skip them.

Related:
- #7112
- #7124

###  Affected Containers

- acme-mailcow