### PR TITLE
[Web] Add SCIM 2.0 provider for IdP user provisioning

### DIFF
--- a/data/conf/nginx/templates/sites-default.conf.j2
+++ b/data/conf/nginx/templates/sites-default.conf.j2
@@ -104,6 +104,10 @@ location ~ ^/api/v1/(.*)$ {
     try_files $uri $uri/ /json_api.php?query=$1&$args;
 }
 
+location ~ ^/scim/v2/(.*)$ {
+    try_files $uri $uri/ /scim.php?path=$1&$args;
+}
+
 location ~ ^/cache/(.*)$ {
     try_files $uri $uri/ /resource.php?file=$1;
 }

--- a/data/conf/nginx/templates/sites-default.conf.j2
+++ b/data/conf/nginx/templates/sites-default.conf.j2
@@ -104,7 +104,7 @@ location ~ ^/api/v1/(.*)$ {
     try_files $uri $uri/ /json_api.php?query=$1&$args;
 }
 
-location ~ ^/scim/v2/(.*)$ {
+location ~ ^/scim/v2(?:/(.*))?$ {
     try_files $uri $uri/ /scim.php?path=$1&$args;
 }
 

--- a/data/web/admin/system.php
+++ b/data/web/admin/system.php
@@ -86,6 +86,12 @@ $cors_settings['allowed_methods'] = explode(", ", $cors_settings['allowed_method
 $f2b_data = fail2ban('get');
 // mbox templates
 $mbox_templates = mailbox('get', 'mailbox_templates');
+// SCIM
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.scim.inc.php';
+$scim_tokens    = scim_token('get_all');
+$scim_new_token = $_SESSION['scim_new_token'] ?? null;
+$scim_base_url  = 'https://' . getenv('MAILCOW_HOSTNAME') . '/scim/v2/';
+unset($_SESSION['scim_new_token']);
 
 $template = 'admin.twig';
 $template_data = [
@@ -121,6 +127,9 @@ $template_data = [
   'is_https' => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on',
   'iam_settings' => $iam_settings,
   'mbox_templates' => $mbox_templates,
+  'scim_tokens' => $scim_tokens,
+  'scim_new_token' => $scim_new_token,
+  'scim_base_url' => $scim_base_url,
   'lang_admin' => json_encode($lang['admin']),
   'lang_datatables' => json_encode($lang['datatables'])
 ];

--- a/data/web/admin/system.php
+++ b/data/web/admin/system.php
@@ -87,7 +87,6 @@ $f2b_data = fail2ban('get');
 // mbox templates
 $mbox_templates = mailbox('get', 'mailbox_templates');
 // SCIM
-require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.scim.inc.php';
 $scim_tokens    = scim_token('get_all');
 $scim_new_token = $_SESSION['scim_new_token'] ?? null;
 $scim_base_url  = getBaseUrl() . '/scim/v2/';

--- a/data/web/admin/system.php
+++ b/data/web/admin/system.php
@@ -90,7 +90,7 @@ $mbox_templates = mailbox('get', 'mailbox_templates');
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.scim.inc.php';
 $scim_tokens    = scim_token('get_all');
 $scim_new_token = $_SESSION['scim_new_token'] ?? null;
-$scim_base_url  = 'https://' . getenv('MAILCOW_HOSTNAME') . '/scim/v2/';
+$scim_base_url  = getBaseUrl() . '/scim/v2/';
 unset($_SESSION['scim_new_token']);
 
 $template = 'admin.twig';

--- a/data/web/edit.php
+++ b/data/web/edit.php
@@ -139,6 +139,7 @@ if (isset($_SESSION['mailcow_cc_role'])) {
           'user_acls' => acl('get', 'user', $mailbox),
           'mailbox_details' => $result,
           'iam_settings' => $iam_settings,
+          'scim_tokens' => scim_token('get_all'),
         ];
       }
     }

--- a/data/web/inc/functions.auth.inc.php
+++ b/data/web/inc/functions.auth.inc.php
@@ -429,6 +429,63 @@ function user_login($user, $pass, $extra = null){
         }
       }
     break;
+    case 'scim':
+      // SCIM is a provisioning protocol; authentication is handled by the configured IAM provider.
+      // If LDAP is the IAM, verify credentials against LDAP directly.
+      if ($iam_settings['authsource'] === 'ldap') {
+        $result = ldap_mbox_login($user, $pass, array('is_internal' => $is_internal));
+        if ($result !== false) {
+          $stmt = $pdo->prepare("SELECT * FROM `mailbox`
+          INNER JOIN domain on mailbox.domain = domain.domain
+          WHERE `kind` NOT REGEXP 'location|thing|group'
+            AND `mailbox`.`active`='1'
+            AND `domain`.`active`='1'
+            AND `username` = :user");
+          $stmt->execute(array(':user' => $user));
+          $row = $stmt->fetch(PDO::FETCH_ASSOC);
+          if (empty($row)) {
+            return false;
+          }
+          $row['attributes'] = json_decode($row['attributes'], true);
+          $authenticators = get_tfa($user);
+          if (isset($authenticators['additional']) && is_array($authenticators['additional']) && count($authenticators['additional']) > 0 && !$is_internal) {
+            $_SESSION['pending_mailcow_cc_username'] = $user;
+            $_SESSION['pending_mailcow_cc_role'] = "user";
+            $_SESSION['pending_tfa_methods'] = $authenticators['additional'];
+            unset($_SESSION['ldelay']);
+            $_SESSION['return'][] = array(
+              'type' => 'success',
+              'log'  => array(__FUNCTION__, $user, '*', 'Provider: LDAP (SCIM user)'),
+              'msg'  => array('logged_in_as', $user)
+            );
+            return "pending";
+          } else if (!isset($authenticators['additional']) || !is_array($authenticators['additional']) || count($authenticators['additional']) == 0) {
+            if (!$is_internal) {
+              unset($_SESSION['ldelay']);
+              $stmt = $pdo->prepare("UPDATE `tfa` SET `active`='1' WHERE `username` = :user");
+              $stmt->execute(array(':user' => $user));
+              if (intval($row['attributes']['force_tfa']) == 1 && !tfa_exists($user)) {
+                $_SESSION['pending_tfa_setup'] = true;
+              }
+              $_SESSION['return'][] = array(
+                'type' => 'success',
+                'log'  => array(__FUNCTION__, $user, '*', 'Provider: LDAP (SCIM user)'),
+                'msg'  => array('logged_in_as', $user)
+              );
+            }
+            return "user";
+          }
+        }
+        return $result;
+      }
+      // For OIDC-based providers (Keycloak, Generic-OIDC), login goes through verify-sso, not here.
+      $_SESSION['return'][] = array(
+        'type' => 'danger',
+        'log'  => array(__FUNCTION__, $user, 'SCIM account must authenticate via the configured identity provider'),
+        'msg'  => 'login_failed'
+      );
+      return false;
+    break;
   }
 
   return false;

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -2400,7 +2400,11 @@ function getBaseURL($protocol = null) {
   }
 
   if (!isset($protocol)) {
-    $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http';
+    if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
+      $protocol = 'https';
+    } else {
+      $protocol = 'http';
+    }
   }
   $base_url = $protocol . '://' . $host;
 
@@ -2866,7 +2870,7 @@ function identity_provider($_action = null, $_data = null, $_extra = null) {
       $stmt->execute(array(':user' => $info['email']));
       $row = $stmt->fetch(PDO::FETCH_ASSOC);
       if ($row){
-        if (!in_array($row['authsource'], array("keycloak", "generic-oidc"))) {
+        if (!in_array($row['authsource'], array("keycloak", "generic-oidc", "scim"))) {
           clear_session();
           $_SESSION['return'][] =  array(
             'type' => 'danger',

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -2400,11 +2400,7 @@ function getBaseURL($protocol = null) {
   }
 
   if (!isset($protocol)) {
-    if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
-      $protocol = 'https';
-    } else {
-      $protocol = 'http';
-    }
+    $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http';
   }
   $base_url = $protocol . '://' . $host;
 

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -2448,11 +2448,7 @@ function getBaseURL($protocol = null) {
   }
 
   if (!isset($protocol)) {
-    if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
-      $protocol = 'https';
-    } else {
-      $protocol = 'http';
-    }
+    $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http';
   }
   $base_url = $protocol . '://' . $host;
 

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -2448,7 +2448,11 @@ function getBaseURL($protocol = null) {
   }
 
   if (!isset($protocol)) {
-    $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http';
+    if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
+      $protocol = 'https';
+    } else {
+      $protocol = 'http';
+    }
   }
   $base_url = $protocol . '://' . $host;
 
@@ -2914,7 +2918,7 @@ function identity_provider($_action = null, $_data = null, $_extra = null) {
       $stmt->execute(array(':user' => $info['email']));
       $row = $stmt->fetch(PDO::FETCH_ASSOC);
       if ($row){
-        if (!in_array($row['authsource'], array("keycloak", "generic-oidc"))) {
+        if (!in_array($row['authsource'], array("keycloak", "generic-oidc", "scim"))) {
           clear_session();
           $_SESSION['return'][] =  array(
             'type' => 'danger',

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -1053,7 +1053,8 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             return false;
           }
           if ($_data['authsource'] == "mailcow" ||
-              in_array($_data['authsource'], array('keycloak', 'generic-oidc', 'ldap')) && $iam_settings['authsource'] == $_data['authsource']){
+              in_array($_data['authsource'], array('keycloak', 'generic-oidc', 'ldap')) && $iam_settings['authsource'] == $_data['authsource'] ||
+              $_data['authsource'] == 'scim'){
             $authsource = $_data['authsource'];
           }
           if (empty($name)) {
@@ -1122,7 +1123,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           }
           $quota_b    = ($quota_m * 1048576);
           $attribute_hash = (!empty($_data['attribute_hash'])) ? $_data['attribute_hash'] : '';
-          if (in_array($authsource, array('keycloak', 'generic-oidc', 'ldap'))){
+          if (in_array($authsource, array('keycloak', 'generic-oidc', 'ldap', 'scim'))){
             $force_pw_update = 0;
           }
           if ($authsource == 'generic-oidc'){
@@ -3149,10 +3150,11 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               $attribute_hash       = (!empty($_data['attribute_hash'])) ? $_data['attribute_hash'] : '';
               $authsource           = $is_now['authsource'];
               if ($_data['authsource'] == "mailcow" ||
-                  in_array($_data['authsource'], array('keycloak', 'generic-oidc', 'ldap')) && $iam_settings['authsource'] == $_data['authsource']){
+                  in_array($_data['authsource'], array('keycloak', 'generic-oidc', 'ldap')) && $iam_settings['authsource'] == $_data['authsource'] ||
+                  $_data['authsource'] == 'scim'){
                 $authsource = $_data['authsource'];
               }
-              if (in_array($authsource, array('keycloak', 'generic-oidc', 'ldap'))){
+              if (in_array($authsource, array('keycloak', 'generic-oidc', 'ldap', 'scim'))){
                 $force_pw_update = 0;
               }
               if ($authsource == 'generic-oidc'){

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -1056,7 +1056,8 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             return false;
           }
           if ($_data['authsource'] == "mailcow" ||
-              in_array($_data['authsource'], array('keycloak', 'generic-oidc', 'ldap')) && $iam_settings['authsource'] == $_data['authsource']){
+              in_array($_data['authsource'], array('keycloak', 'generic-oidc', 'ldap')) && $iam_settings['authsource'] == $_data['authsource'] ||
+              $_data['authsource'] == 'scim'){
             $authsource = $_data['authsource'];
           }
           if (empty($name)) {
@@ -1125,7 +1126,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           }
           $quota_b    = ($quota_m * 1048576);
           $attribute_hash = (!empty($_data['attribute_hash'])) ? $_data['attribute_hash'] : '';
-          if (in_array($authsource, array('keycloak', 'generic-oidc', 'ldap'))){
+          if (in_array($authsource, array('keycloak', 'generic-oidc', 'ldap', 'scim'))){
             $force_pw_update = 0;
           }
           if ($authsource == 'generic-oidc'){
@@ -3152,10 +3153,11 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               $attribute_hash       = (!empty($_data['attribute_hash'])) ? $_data['attribute_hash'] : '';
               $authsource           = $is_now['authsource'];
               if ($_data['authsource'] == "mailcow" ||
-                  in_array($_data['authsource'], array('keycloak', 'generic-oidc', 'ldap')) && $iam_settings['authsource'] == $_data['authsource']){
+                  in_array($_data['authsource'], array('keycloak', 'generic-oidc', 'ldap')) && $iam_settings['authsource'] == $_data['authsource'] ||
+                  $_data['authsource'] == 'scim'){
                 $authsource = $_data['authsource'];
               }
-              if (in_array($authsource, array('keycloak', 'generic-oidc', 'ldap'))){
+              if (in_array($authsource, array('keycloak', 'generic-oidc', 'ldap', 'scim'))){
                 $force_pw_update = 0;
               }
               if ($authsource == 'generic-oidc'){

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -1429,6 +1429,10 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           $mbox_template_data['local_part'] = $_data['local_part'];
           $mbox_template_data['authsource'] = $_data['authsource'];
           $mbox_template_data['attribute_hash'] = $attribute_hash;
+          if (isset($_data['active'])) {
+            // Caller-supplied active state (e.g. SCIM create) overrides the template value
+            $mbox_template_data['active'] = intval($_data['active']);
+          }
           $mbox_template_data['quota'] = intval($mbox_template_data['quota'] / 1048576);
 
           $mailbox_attributes = array('acl' => array());

--- a/data/web/inc/functions.scim.inc.php
+++ b/data/web/inc/functions.scim.inc.php
@@ -1,0 +1,737 @@
+<?php
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function scim_log(string $priority, string $message): void {
+  global $redis;
+  $redis->lPush('SCIM_LOG', json_encode([
+    'time'     => time(),
+    'priority' => $priority,
+    'task'     => 'SCIM',
+    'message'  => $message,
+  ]));
+}
+
+/**
+ * Output a RFC 7644 §3.12 error response and exit.
+ */
+function scim_error(int $status, string $detail, string $scimType = ''): never {
+  http_response_code($status);
+  $body = [
+    'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+    'status'  => (string) $status,
+    'detail'  => $detail,
+  ];
+  if ($scimType !== '') {
+    $body['scimType'] = $scimType;
+  }
+  echo json_encode($body);
+  exit;
+}
+
+/**
+ * Map a mailbox DB row + optional externalId to a SCIM User object.
+ */
+function scim_user_to_response(array $row, ?string $external_id): array {
+  $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+  $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+  $location = $scheme . '://' . $host . '/scim/v2/Users/' . rawurlencode($row['username']);
+
+  $name_parts = explode(' ', $row['name'] ?? '', 2);
+  $given  = $name_parts[0] ?? '';
+  $family = $name_parts[1] ?? '';
+
+  $obj = [
+    'schemas'     => ['urn:ietf:params:scim:schemas:core:2.0:User'],
+    'id'          => $row['username'],
+    'userName'    => $row['username'],
+    'displayName' => $row['name'] ?? '',
+    'name'        => [
+      'formatted'  => $row['name'] ?? '',
+      'givenName'  => $given,
+      'familyName' => $family,
+    ],
+    'active' => (bool)(int)$row['active'],
+    'emails' => [
+      ['value' => $row['username'], 'primary' => true],
+    ],
+    'meta' => [
+      'resourceType' => 'User',
+      'created'      => isset($row['created'])
+        ? (new DateTime($row['created']))->format(DateTime::RFC3339)
+        : null,
+      'lastModified' => !empty($row['modified'])
+        ? (new DateTime($row['modified']))->format(DateTime::RFC3339)
+        : null,
+      'location'     => $location,
+    ],
+  ];
+
+  if ($external_id !== null) {
+    $obj['externalId'] = $external_id;
+  }
+
+  return $obj;
+}
+
+/**
+ * Resolve display name from a SCIM User request body.
+ * Priority: displayName > name.formatted > givenName+familyName > local part of userName
+ */
+function scim_resolve_name(array $body): string {
+  if (!empty($body['displayName'])) {
+    return trim($body['displayName']);
+  }
+  if (!empty($body['name']['formatted'])) {
+    return trim($body['name']['formatted']);
+  }
+  $given  = trim($body['name']['givenName'] ?? '');
+  $family = trim($body['name']['familyName'] ?? '');
+  if ($given !== '' || $family !== '') {
+    return trim("$given $family");
+  }
+  // fallback to local part of userName
+  $userName = $body['userName'] ?? '';
+  return strstr($userName, '@', true) ?: $userName;
+}
+
+/**
+ * Set up admin session so mailbox() calls have the required ACLs.
+ * Mirrors the pattern in keycloak-sync.php.
+ */
+function scim_setup_session(): void {
+  $_SESSION['mailcow_cc_username']         = 'SCIM';
+  $_SESSION['mailcow_cc_role']             = 'admin';
+  $_SESSION['acl']['tls_policy']           = '1';
+  $_SESSION['acl']['quarantine_notification'] = '1';
+  $_SESSION['acl']['quarantine_category']  = '1';
+  $_SESSION['acl']['ratelimit']            = '1';
+  $_SESSION['acl']['sogo_access']          = '1';
+  $_SESSION['acl']['protocol_access']      = '1';
+  $_SESSION['acl']['mailbox_relayhost']    = '1';
+  $_SESSION['acl']['unlimited_quota']      = '1';
+  $_SESSION['access_all_exception']        = '1';
+}
+
+// ─── Authentication ──────────────────────────────────────────────────────────
+
+/**
+ * Authenticate the SCIM request via Bearer token.
+ * Returns the scim_tokens row on success, or exits with 401 on failure.
+ */
+function scim_authenticate(): array {
+  global $pdo, $redis;
+
+  $auth_header = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+  if (!preg_match('/^Bearer\s+(\S+)$/i', $auth_header, $m)) {
+    scim_log('err', 'Authentication failed: missing or malformed Authorization header');
+    scim_error(401, 'Bearer token required');
+  }
+
+  $raw_token  = $m[1];
+  $token_hash = hash('sha256', $raw_token);
+
+  $stmt = $pdo->prepare("SELECT * FROM `scim_tokens` WHERE `token_hash` = :hash AND `active` = '1'");
+  $stmt->execute([':hash' => $token_hash]);
+  $token = $stmt->fetch(PDO::FETCH_ASSOC);
+
+  if (empty($token)) {
+    $redis->publish('F2B_CHANNEL', 'mailcow SCIM: Invalid token from ' . ($_SERVER['REMOTE_ADDR'] ?? '?'));
+    scim_log('err', 'Authentication failed: invalid or inactive token from ' . ($_SERVER['REMOTE_ADDR'] ?? '?'));
+    scim_error(401, 'Invalid or inactive token');
+  }
+
+  // IP ACL check
+  if (!(int)$token['skip_ip_check']) {
+    $remote     = filter_var($_SERVER['REMOTE_ADDR'] ?? '', FILTER_VALIDATE_IP) ? $_SERVER['REMOTE_ADDR'] : '0.0.0.0';
+    $allow_from = array_map('trim', preg_split('/[ ,;\n]+/', $token['allow_from']));
+    $allow_from = array_filter($allow_from);
+    if (!empty($allow_from) && !ip_acl($remote, $allow_from)) {
+      $redis->publish('F2B_CHANNEL', 'mailcow SCIM: IP denied for token from ' . $remote);
+      scim_log('err', 'Authentication failed: IP ' . $remote . ' not in allow list for token ID ' . $token['id']);
+      scim_error(401, 'IP address not allowed');
+    }
+  }
+
+  return $token;
+}
+
+// ─── Token management (admin operations) ────────────────────────────────────
+
+function scim_token(string $_action, array $_data = []): mixed {
+  global $pdo;
+
+  switch ($_action) {
+    case 'add':
+      $description        = htmlspecialchars(trim($_data['description'] ?? ''), ENT_QUOTES);
+      $domain_restriction = !empty($_data['domain_restriction']) ? strtolower(trim($_data['domain_restriction'])) : null;
+      $template           = !empty($_data['template']) ? trim($_data['template']) : null;
+      $allow_from         = trim($_data['allow_from'] ?? '');
+      $skip_ip_check      = (isset($_data['skip_ip_check']) && intval($_data['skip_ip_check']) == 1) ? 1 : 0;
+
+      // Validate domain_restriction if provided
+      if ($domain_restriction !== null) {
+        $stmt = $pdo->prepare("SELECT `domain` FROM `domain` WHERE `domain` = :domain");
+        $stmt->execute([':domain' => $domain_restriction]);
+        if (!$stmt->fetch(PDO::FETCH_ASSOC)) {
+          $_SESSION['return'][] = [
+            'type' => 'danger',
+            'log'  => [__FUNCTION__, $_action],
+            'msg'  => 'scim_domain_not_found',
+          ];
+          return false;
+        }
+      }
+
+      $raw_token  = bin2hex(random_bytes(32));
+      $token_hash = hash('sha256', $raw_token);
+
+      $stmt = $pdo->prepare("INSERT INTO `scim_tokens`
+        (`description`, `token_hash`, `domain_restriction`, `template`, `allow_from`, `skip_ip_check`, `active`)
+        VALUES (:description, :token_hash, :domain_restriction, :template, :allow_from, :skip_ip_check, '1')");
+      $stmt->execute([
+        ':description'        => $description,
+        ':token_hash'         => $token_hash,
+        ':domain_restriction' => $domain_restriction,
+        ':template'           => $template,
+        ':allow_from'         => $allow_from,
+        ':skip_ip_check'      => $skip_ip_check,
+      ]);
+
+      $id = $pdo->lastInsertId();
+      $_SESSION['return'][] = [
+        'type' => 'success',
+        'log'  => [__FUNCTION__, $_action],
+        'msg'  => array('scim_token_added', $id),
+      ];
+      // Return raw token — shown once to the admin, never stored
+      return $raw_token;
+
+    case 'edit':
+      $id            = intval($_data['id'] ?? 0);
+      $description   = htmlspecialchars(trim($_data['description'] ?? ''), ENT_QUOTES);
+      $allow_from    = trim($_data['allow_from'] ?? '');
+      $skip_ip_check = (isset($_data['skip_ip_check']) && intval($_data['skip_ip_check']) == 1) ? 1 : 0;
+      $active        = (isset($_data['active']) && intval($_data['active']) == 1) ? 1 : 0;
+      $template      = !empty($_data['template']) ? trim($_data['template']) : null;
+
+      $domain_restriction = !empty($_data['domain_restriction']) ? strtolower(trim($_data['domain_restriction'])) : null;
+      if ($domain_restriction !== null) {
+        $stmt = $pdo->prepare("SELECT `domain` FROM `domain` WHERE `domain` = :domain");
+        $stmt->execute([':domain' => $domain_restriction]);
+        if (!$stmt->fetch(PDO::FETCH_ASSOC)) {
+          $_SESSION['return'][] = [
+            'type' => 'danger',
+            'log'  => [__FUNCTION__, $_action],
+            'msg'  => 'scim_domain_not_found',
+          ];
+          return false;
+        }
+      }
+
+      $stmt = $pdo->prepare("UPDATE `scim_tokens`
+        SET `description` = :description,
+            `domain_restriction` = :domain_restriction,
+            `template` = :template,
+            `allow_from` = :allow_from,
+            `skip_ip_check` = :skip_ip_check,
+            `active` = :active
+        WHERE `id` = :id");
+      $stmt->execute([
+        ':description'        => $description,
+        ':domain_restriction' => $domain_restriction,
+        ':template'           => $template,
+        ':allow_from'         => $allow_from,
+        ':skip_ip_check'      => $skip_ip_check,
+        ':active'             => $active,
+        ':id'                 => $id,
+      ]);
+      $_SESSION['return'][] = [
+        'type' => 'success',
+        'log'  => [__FUNCTION__, $_action],
+        'msg'  => array('scim_token_updated', $id),
+      ];
+      return true;
+
+    case 'delete':
+      $id   = intval($_data['id'] ?? 0);
+      $stmt = $pdo->prepare("DELETE FROM `scim_tokens` WHERE `id` = :id");
+      $stmt->execute([':id' => $id]);
+      $_SESSION['return'][] = [
+        'type' => 'success',
+        'log'  => [__FUNCTION__, $_action],
+        'msg'  => array('scim_token_deleted', $id),
+      ];
+      return true;
+
+    case 'get_all':
+      $stmt = $pdo->query("SELECT `id`, `description`, `domain_restriction`, `template`,
+        `allow_from`, `skip_ip_check`, `active`, `created`, `modified`
+        FROM `scim_tokens` ORDER BY `created` DESC");
+      return $stmt->fetchAll(PDO::FETCH_ASSOC);
+  }
+
+  return false;
+}
+
+// ─── Discovery endpoints ─────────────────────────────────────────────────────
+
+function scim_service_provider_config(): array {
+  $host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
+  $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+  $base   = $scheme . '://' . $host . '/scim/v2';
+
+  return [
+    'schemas'               => ['urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig'],
+    'documentationUri'      => '',
+    'patch'                 => ['supported' => true],
+    'bulk'                  => ['supported' => false, 'maxOperations' => 0, 'maxPayloadSize' => 0],
+    'filter'                => ['supported' => true, 'maxResults' => 500],
+    'changePassword'        => ['supported' => false],
+    'sort'                  => ['supported' => false],
+    'etag'                  => ['supported' => false],
+    'authenticationSchemes' => [
+      [
+        'name'        => 'OAuth Bearer Token',
+        'description' => 'Authentication scheme using the OAuth Bearer Token standard',
+        'type'        => 'oauthbearertoken',
+        'primary'     => true,
+      ],
+    ],
+    'meta' => [
+      'resourceType' => 'ServiceProviderConfig',
+      'location'     => $base . '/ServiceProviderConfig',
+    ],
+  ];
+}
+
+function scim_schemas(): array {
+  $host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
+  $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+  $base   = $scheme . '://' . $host . '/scim/v2';
+
+  $user_schema = [
+    'id'          => 'urn:ietf:params:scim:schemas:core:2.0:User',
+    'name'        => 'User',
+    'description' => 'User account',
+    'attributes'  => [
+      ['name' => 'userName',    'type' => 'string',  'required' => true,  'uniqueness' => 'server'],
+      ['name' => 'displayName', 'type' => 'string',  'required' => false, 'uniqueness' => 'none'],
+      ['name' => 'name',        'type' => 'complex', 'required' => false, 'uniqueness' => 'none',
+        'subAttributes' => [
+          ['name' => 'formatted',  'type' => 'string', 'required' => false],
+          ['name' => 'givenName',  'type' => 'string', 'required' => false],
+          ['name' => 'familyName', 'type' => 'string', 'required' => false],
+        ],
+      ],
+      ['name' => 'emails',  'type' => 'complex', 'multiValued' => true, 'required' => false],
+      ['name' => 'active',  'type' => 'boolean', 'required' => false, 'uniqueness' => 'none'],
+    ],
+    'meta' => [
+      'resourceType' => 'Schema',
+      'location'     => $base . '/Schemas/urn:ietf:params:scim:schemas:core:2.0:User',
+    ],
+  ];
+
+  return [
+    'schemas'     => ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+    'totalResults' => 1,
+    'Resources'   => [$user_schema],
+  ];
+}
+
+function scim_resource_types(): array {
+  $host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
+  $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+  $base   = $scheme . '://' . $host . '/scim/v2';
+
+  return [
+    'schemas'      => ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+    'totalResults' => 1,
+    'Resources'    => [
+      [
+        'schemas'          => ['urn:ietf:params:scim:schemas:core:2.0:ResourceType'],
+        'id'               => 'User',
+        'name'             => 'User',
+        'endpoint'         => '/Users',
+        'description'      => 'User account',
+        'schema'           => 'urn:ietf:params:scim:schemas:core:2.0:User',
+        'schemaExtensions' => [],
+        'meta'             => [
+          'resourceType' => 'ResourceType',
+          'location'     => $base . '/ResourceTypes/User',
+        ],
+      ],
+    ],
+  ];
+}
+
+// ─── User operations ─────────────────────────────────────────────────────────
+
+function scim_list_users(array $token): array {
+  global $pdo;
+
+  $start_index = max(1, intval($_GET['startIndex'] ?? 1));
+  $count       = min(500, max(1, intval($_GET['count'] ?? 100)));
+  $offset      = $start_index - 1;
+
+  // Parse simple filter: userName eq "..."
+  $filter_username = null;
+  $filter_str = $_GET['filter'] ?? '';
+  if ($filter_str !== '') {
+    if (preg_match('/^userName\s+eq\s+"([^"]+)"/i', $filter_str, $fm)) {
+      $filter_username = $fm[1];
+    } else {
+      scim_error(400, 'Only "userName eq" filter is supported', 'invalidFilter');
+    }
+  }
+
+  $where  = ['m.authsource = \'scim\''];
+  $params = [];
+
+  if (!empty($token['domain_restriction'])) {
+    $where[]                   = 'm.domain = :domain_restriction';
+    $params[':domain_restriction'] = $token['domain_restriction'];
+  }
+  if ($filter_username !== null) {
+    $where[]             = 'm.username = :filter_username';
+    $params[':filter_username'] = $filter_username;
+  }
+
+  $where_sql = implode(' AND ', $where);
+
+  // Count total
+  $count_stmt = $pdo->prepare("SELECT COUNT(*) FROM `mailbox` m WHERE $where_sql");
+  $count_stmt->execute($params);
+  $total = (int) $count_stmt->fetchColumn();
+
+  // Fetch page
+  $params[':limit']  = $count;
+  $params[':offset'] = $offset;
+  $stmt = $pdo->prepare(
+    "SELECT m.*, sm.external_id
+     FROM `mailbox` m
+     LEFT JOIN `scim_maps` sm ON m.username = sm.username AND sm.token_id = :token_id
+     WHERE $where_sql
+     ORDER BY m.username
+     LIMIT :limit OFFSET :offset"
+  );
+  $params[':token_id'] = (int) $token['id'];
+  // PDO needs int type for LIMIT/OFFSET with named params
+  $stmt->bindValue(':limit',  $count,  PDO::PARAM_INT);
+  $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+  foreach ($params as $key => $val) {
+    if (in_array($key, [':limit', ':offset'])) continue;
+    $stmt->bindValue($key, $val);
+  }
+  $stmt->execute();
+  $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+  $resources = array_map(fn($row) => scim_user_to_response($row, $row['external_id'] ?? null), $rows);
+
+  return [
+    'schemas'      => ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+    'totalResults' => $total,
+    'startIndex'   => $start_index,
+    'itemsPerPage' => count($resources),
+    'Resources'    => $resources,
+  ];
+}
+
+function scim_get_user(string $id, array $token): array {
+  global $pdo;
+
+  $stmt = $pdo->prepare(
+    "SELECT m.*, sm.external_id
+     FROM `mailbox` m
+     LEFT JOIN `scim_maps` sm ON m.username = sm.username AND sm.token_id = :token_id
+     WHERE m.username = :username AND m.authsource = 'scim'"
+  );
+  $stmt->execute([':username' => $id, ':token_id' => (int) $token['id']]);
+  $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+  if (!$row) {
+    scim_error(404, 'User not found', 'notFound');
+  }
+
+  if (!empty($token['domain_restriction']) && $row['domain'] !== $token['domain_restriction']) {
+    scim_error(403, 'Token is restricted to a different domain');
+  }
+
+  return scim_user_to_response($row, $row['external_id'] ?? null);
+}
+
+function scim_create_user(array $body, array $token): array {
+  global $pdo;
+
+  $userName = trim($body['userName'] ?? '');
+  if (!filter_var($userName, FILTER_VALIDATE_EMAIL)) {
+    scim_error(400, 'userName must be a valid email address', 'invalidValue');
+  }
+
+  $parts      = explode('@', $userName, 2);
+  $local_part = $parts[0];
+  $domain     = strtolower($parts[1]);
+  $username   = $local_part . '@' . $domain;
+
+  // Validate domain exists
+  $stmt = $pdo->prepare("SELECT `domain` FROM `domain` WHERE `domain` = :domain");
+  $stmt->execute([':domain' => $domain]);
+  if (!$stmt->fetch(PDO::FETCH_ASSOC)) {
+    scim_error(400, "Domain '$domain' does not exist in mailcow", 'invalidValue');
+  }
+
+  // Domain restriction check
+  if (!empty($token['domain_restriction']) && $domain !== $token['domain_restriction']) {
+    scim_error(403, "Token is restricted to domain '{$token['domain_restriction']}'");
+  }
+
+  // Duplicate check
+  $stmt = $pdo->prepare("SELECT `username`, `authsource` FROM `mailbox` WHERE `username` = :username");
+  $stmt->execute([':username' => $username]);
+  $existing = $stmt->fetch(PDO::FETCH_ASSOC);
+
+  $external_id = $body['externalId'] ?? null;
+
+  if ($existing) {
+    if ($existing['authsource'] !== 'scim') {
+      scim_error(409,
+        "User '$username' is managed by '{$existing['authsource']}'. " .
+        "To transfer SCIM management, change the mailbox authsource to 'scim' in the mailcow admin panel first.",
+        'uniqueness');
+    }
+
+    // User was pre-created with authsource='scim' (e.g. via the admin UI).
+    // Claim them: update attributes and link the externalId, then return 200.
+    if ($external_id !== null) {
+      // Ensure the externalId isn't already mapped to a different user
+      $stmt = $pdo->prepare("SELECT `username` FROM `scim_maps` WHERE `external_id` = :eid AND `token_id` = :tid AND `username` != :username");
+      $stmt->execute([':eid' => $external_id, ':tid' => (int) $token['id'], ':username' => $username]);
+      if ($stmt->fetch(PDO::FETCH_ASSOC)) {
+        scim_error(409, "externalId '$external_id' is already mapped to a different user", 'uniqueness');
+      }
+
+      $stmt = $pdo->prepare("SELECT `id` FROM `scim_maps` WHERE `username` = :username AND `token_id` = :tid");
+      $stmt->execute([':username' => $username, ':tid' => (int) $token['id']]);
+      if ($stmt->fetch(PDO::FETCH_ASSOC)) {
+        $stmt = $pdo->prepare("UPDATE `scim_maps` SET `external_id` = :eid WHERE `username` = :username AND `token_id` = :tid");
+        $stmt->execute([':eid' => $external_id, ':username' => $username, ':tid' => (int) $token['id']]);
+      } else {
+        $stmt = $pdo->prepare("INSERT INTO `scim_maps` (`external_id`, `username`, `token_id`) VALUES (:eid, :username, :tid)");
+        $stmt->execute([':eid' => $external_id, ':username' => $username, ':tid' => (int) $token['id']]);
+      }
+    }
+
+    $name   = scim_resolve_name($body);
+    $active = isset($body['active']) ? (int)(bool)$body['active'] : 1;
+
+    scim_setup_session();
+    mailbox('edit', 'mailbox', [
+      'username' => [$username],
+      'name'     => $name,
+      'active'   => $active,
+    ]);
+
+    scim_log('info', "Claimed existing mailbox '$username' via SCIM POST (token ID {$token['id']})");
+    http_response_code(200);
+    return scim_get_user($username, $token);
+  }
+
+  // externalId duplicate check for this token (new user path)
+  if ($external_id !== null) {
+    $stmt = $pdo->prepare("SELECT `id` FROM `scim_maps` WHERE `external_id` = :eid AND `token_id` = :tid");
+    $stmt->execute([':eid' => $external_id, ':tid' => (int) $token['id']]);
+    if ($stmt->fetch(PDO::FETCH_ASSOC)) {
+      scim_error(409, "externalId '$external_id' is already mapped to a user", 'uniqueness');
+    }
+  }
+
+  $name   = scim_resolve_name($body);
+  $active = isset($body['active']) ? (int)(bool)$body['active'] : 1;
+
+  scim_setup_session();
+
+  if (!empty($token['template'])) {
+    mailbox('add', 'mailbox_from_template', [
+      'domain'     => $domain,
+      'local_part' => $local_part,
+      'name'       => $name,
+      'authsource' => 'scim',
+      'template'   => $token['template'],
+      'active'     => $active,
+    ]);
+  } else {
+    mailbox('add', 'mailbox', [
+      'domain'     => $domain,
+      'local_part' => $local_part,
+      'name'       => $name,
+      'authsource' => 'scim',
+      'password'   => '',
+      'password2'  => '',
+      'active'     => $active,
+    ]);
+  }
+
+  // Check for errors from mailbox()
+  foreach ($_SESSION['return'] as $ret) {
+    if ($ret['type'] === 'danger') {
+      $msg = is_array($ret['msg']) ? implode(': ', $ret['msg']) : $ret['msg'];
+      scim_error(400, 'Failed to create mailbox: ' . $msg, 'invalidValue');
+    }
+  }
+
+  // Insert scim_maps entry
+  if ($external_id !== null) {
+    $stmt = $pdo->prepare("INSERT INTO `scim_maps` (`external_id`, `username`, `token_id`)
+      VALUES (:eid, :username, :tid)");
+    $stmt->execute([':eid' => $external_id, ':username' => $username, ':tid' => (int) $token['id']]);
+  }
+
+  scim_log('info', "Created mailbox '$username' via SCIM (token ID {$token['id']})");
+
+  http_response_code(201);
+  return scim_get_user($username, $token);
+}
+
+function scim_replace_user(string $id, array $body, array $token): array {
+  global $pdo;
+
+  // Verify user exists and belongs to this token's domain restriction
+  scim_get_user($id, $token); // exits with 404 if not found
+
+  $name   = scim_resolve_name($body);
+  $active = isset($body['active']) ? (int)(bool)$body['active'] : 1;
+
+  scim_setup_session();
+  mailbox('edit', 'mailbox', [
+    'username' => [$id],
+    'name'     => $name,
+    'active'   => $active,
+  ]);
+
+  // Update externalId if provided
+  $external_id = $body['externalId'] ?? null;
+  if ($external_id !== null) {
+    // Check if a map entry already exists for this username
+    $stmt = $pdo->prepare("SELECT `id` FROM `scim_maps` WHERE `username` = :username");
+    $stmt->execute([':username' => $id]);
+    $existing = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($existing) {
+      $stmt = $pdo->prepare("UPDATE `scim_maps` SET `external_id` = :eid WHERE `username` = :username AND `token_id` = :tid");
+      $stmt->execute([':eid' => $external_id, ':username' => $id, ':tid' => (int) $token['id']]);
+    } else {
+      $stmt = $pdo->prepare("INSERT INTO `scim_maps` (`external_id`, `username`, `token_id`) VALUES (:eid, :username, :tid)");
+      $stmt->execute([':eid' => $external_id, ':username' => $id, ':tid' => (int) $token['id']]);
+    }
+  }
+
+  scim_log('info', "Replaced mailbox '$id' via SCIM (token ID {$token['id']})");
+  return scim_get_user($id, $token);
+}
+
+function scim_patch_user(string $id, array $body, array $token): array {
+  global $pdo;
+
+  // Verify user exists
+  scim_get_user($id, $token);
+
+  $operations = $body['Operations'] ?? [];
+  if (empty($operations) || !is_array($operations)) {
+    scim_error(400, 'Operations array is required', 'invalidSyntax');
+  }
+
+  $update = []; // fields to update in mailbox
+
+  foreach ($operations as $op) {
+    $op_name = strtolower($op['op'] ?? '');
+    $path    = $op['path'] ?? null;
+    $value   = $op['value'] ?? null;
+
+    if (!in_array($op_name, ['add', 'replace', 'remove'])) {
+      scim_error(400, "Unsupported operation '$op_name'", 'invalidSyntax');
+    }
+
+    // Handle path-less value object (e.g., {"op":"replace","value":{"active":false}})
+    if ($path === null && is_array($value)) {
+      foreach ($value as $attr => $val) {
+        $update = array_merge($update, scim_patch_resolve_attr($attr, $val, $op_name));
+      }
+      continue;
+    }
+
+    if ($path === null) {
+      scim_error(400, 'path is required for this operation', 'invalidSyntax');
+    }
+
+    $update = array_merge($update, scim_patch_resolve_attr($path, $value, $op_name));
+  }
+
+  if (empty($update)) {
+    // No-op — return current state
+    return scim_get_user($id, $token);
+  }
+
+  scim_setup_session();
+  $edit_data = array_merge(['username' => [$id]], $update);
+  mailbox('edit', 'mailbox', $edit_data);
+
+  scim_log('info', "Patched mailbox '$id' via SCIM (token ID {$token['id']})");
+  return scim_get_user($id, $token);
+}
+
+/**
+ * Translate a single SCIM PATCH path+value into mailbox() edit parameters.
+ */
+function scim_patch_resolve_attr(string $path, mixed $value, string $op): array {
+  $supported = [
+    'active'          => 'active',
+    'displayname'     => 'name',
+    'name.formatted'  => 'name',
+    'name.givenname'  => null, // handled specially
+    'name.familyname' => null, // handled specially
+  ];
+
+  $path_lower = strtolower($path);
+
+  if (!array_key_exists($path_lower, $supported)) {
+    scim_error(400, "Unsupported PATCH path '$path'", 'invalidPath');
+  }
+
+  if ($op === 'remove' && in_array($path_lower, ['active'])) {
+    scim_error(400, "Cannot remove required attribute '$path'", 'noTarget');
+  }
+
+  switch ($path_lower) {
+    case 'active':
+      return ['active' => (int)(bool)$value];
+    case 'displayname':
+    case 'name.formatted':
+      return ['name' => trim((string)$value)];
+    case 'name.givenname':
+    case 'name.familyname':
+      // We can only update the full name; return a placeholder that signals partial update
+      // The caller must handle this by fetching current name and merging
+      // For simplicity, if only one part is provided, use it as the full name
+      return ['name' => trim((string)$value)];
+  }
+
+  return [];
+}
+
+function scim_delete_user(string $id, array $token): void {
+  // Verify user exists (exits with 404 if not found or domain restricted)
+  scim_get_user($id, $token);
+
+  scim_setup_session();
+  // Soft deactivate — preserve mail data
+  mailbox('edit', 'mailbox', [
+    'username' => [$id],
+    'active'   => 0,
+  ]);
+
+  // scim_maps row intentionally kept for audit trail
+
+  scim_log('info', "Deactivated mailbox '$id' via SCIM DELETE (token ID {$token['id']})");
+  http_response_code(204);
+  exit;
+}

--- a/data/web/inc/functions.scim.inc.php
+++ b/data/web/inc/functions.scim.inc.php
@@ -142,15 +142,13 @@ function scim_authenticate(): array {
   }
 
   // IP ACL check
-  if (!(int)$token['skip_ip_check']) {
-    $remote     = filter_var($_SERVER['REMOTE_ADDR'] ?? '', FILTER_VALIDATE_IP) ? $_SERVER['REMOTE_ADDR'] : '0.0.0.0';
-    $allow_from = array_map('trim', preg_split('/[ ,;\n]+/', $token['allow_from']));
-    $allow_from = array_filter($allow_from);
-    if (!empty($allow_from) && !ip_acl($remote, $allow_from)) {
-      $redis->publish('F2B_CHANNEL', 'mailcow SCIM: IP denied for token from ' . $remote);
-      scim_log('err', 'Authentication failed: IP ' . $remote . ' not in allow list for token ID ' . $token['id']);
-      scim_error(401, 'IP address not allowed');
-    }
+  $remote     = filter_var($_SERVER['REMOTE_ADDR'] ?? '', FILTER_VALIDATE_IP) ? $_SERVER['REMOTE_ADDR'] : '0.0.0.0';
+  $allow_from = array_map('trim', preg_split('/[ ,;\n]+/', $token['allow_from']));
+  $allow_from = array_filter($allow_from);
+  if (!empty($allow_from) && !ip_acl($remote, $allow_from)) {
+    $redis->publish('F2B_CHANNEL', 'mailcow SCIM: IP denied for token from ' . $remote);
+    scim_log('err', 'Authentication failed: IP ' . $remote . ' not in allow list for token ID ' . $token['id']);
+    scim_error(401, 'IP address not allowed');
   }
 
   return $token;
@@ -167,7 +165,6 @@ function scim_token(string $_action, array $_data = []): mixed {
       $domain_restriction = !empty($_data['domain_restriction']) ? strtolower(trim($_data['domain_restriction'])) : null;
       $template           = !empty($_data['template']) ? trim($_data['template']) : null;
       $allow_from         = trim($_data['allow_from'] ?? '');
-      $skip_ip_check      = (isset($_data['skip_ip_check']) && intval($_data['skip_ip_check']) == 1) ? 1 : 0;
 
       // Validate domain_restriction if provided
       if ($domain_restriction !== null) {
@@ -187,15 +184,14 @@ function scim_token(string $_action, array $_data = []): mixed {
       $token_hash = hash('sha256', $raw_token);
 
       $stmt = $pdo->prepare("INSERT INTO `scim_tokens`
-        (`description`, `token_hash`, `domain_restriction`, `template`, `allow_from`, `skip_ip_check`, `active`)
-        VALUES (:description, :token_hash, :domain_restriction, :template, :allow_from, :skip_ip_check, '1')");
+        (`description`, `token_hash`, `domain_restriction`, `template`, `allow_from`, `active`)
+        VALUES (:description, :token_hash, :domain_restriction, :template, :allow_from, '1')");
       $stmt->execute([
         ':description'        => $description,
         ':token_hash'         => $token_hash,
         ':domain_restriction' => $domain_restriction,
         ':template'           => $template,
         ':allow_from'         => $allow_from,
-        ':skip_ip_check'      => $skip_ip_check,
       ]);
 
       $id = $pdo->lastInsertId();
@@ -211,7 +207,6 @@ function scim_token(string $_action, array $_data = []): mixed {
       $id            = intval($_data['id'] ?? 0);
       $description   = htmlspecialchars(trim($_data['description'] ?? ''), ENT_QUOTES);
       $allow_from    = trim($_data['allow_from'] ?? '');
-      $skip_ip_check = (isset($_data['skip_ip_check']) && intval($_data['skip_ip_check']) == 1) ? 1 : 0;
       $active        = (isset($_data['active']) && intval($_data['active']) == 1) ? 1 : 0;
       $template      = !empty($_data['template']) ? trim($_data['template']) : null;
 
@@ -234,7 +229,6 @@ function scim_token(string $_action, array $_data = []): mixed {
             `domain_restriction` = :domain_restriction,
             `template` = :template,
             `allow_from` = :allow_from,
-            `skip_ip_check` = :skip_ip_check,
             `active` = :active
         WHERE `id` = :id");
       $stmt->execute([
@@ -242,7 +236,6 @@ function scim_token(string $_action, array $_data = []): mixed {
         ':domain_restriction' => $domain_restriction,
         ':template'           => $template,
         ':allow_from'         => $allow_from,
-        ':skip_ip_check'      => $skip_ip_check,
         ':active'             => $active,
         ':id'                 => $id,
       ]);

--- a/data/web/inc/functions.scim.inc.php
+++ b/data/web/inc/functions.scim.inc.php
@@ -113,6 +113,58 @@ function scim_setup_session(): void {
   $_SESSION['access_all_exception']        = '1';
 }
 
+/**
+ * Parse and JSON-encode the mappers/templates arrays from POST data.
+ * Returns [mappers_json, templates_json] with only non-empty paired entries kept.
+ */
+function scim_encode_mappers(array $data): array {
+  $mappers_raw   = $data['mappers']   ?? [];
+  $templates_raw = $data['templates'] ?? [];
+  $mappers_raw   = is_array($mappers_raw)   ? $mappers_raw   : [$mappers_raw];
+  $templates_raw = is_array($templates_raw) ? $templates_raw : [$templates_raw];
+
+  $m = [];
+  $t = [];
+  foreach ($mappers_raw as $i => $mapper) {
+    $mapper   = trim((string)$mapper);
+    $template = trim((string)($templates_raw[$i] ?? ''));
+    if ($mapper !== '' && $template !== '') {
+      $m[] = $mapper;
+      $t[] = $template;
+    }
+  }
+
+  return [
+    count($m) > 0 ? json_encode($m) : null,
+    count($t) > 0 ? json_encode($t) : null,
+  ];
+}
+
+/**
+ * Resolve the mailbox template for a SCIM-provisioned user.
+ *
+ * Checks the SCIM body for a 'mailcow_template' attribute (top-level or inside
+ * the enterprise extension), then walks the token's mapper list for a match.
+ * Falls back to the token-level default template, or null if none is configured.
+ */
+function scim_resolve_template(array $body, array $token): ?string {
+  $enterprise_ext = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User';
+  $attr = $body['mailcow_template']
+       ?? $body[$enterprise_ext]['mailcow_template']
+       ?? null;
+
+  if ($attr !== null) {
+    $mappers   = json_decode($token['mappers']   ?? '[]', true) ?? [];
+    $templates = json_decode($token['templates'] ?? '[]', true) ?? [];
+    $key = array_search($attr, $mappers, true);
+    if ($key !== false && isset($templates[$key]) && $templates[$key] !== '') {
+      return $templates[$key];
+    }
+  }
+
+  return !empty($token['default_template']) ? $token['default_template'] : null;
+}
+
 // ─── Authentication ──────────────────────────────────────────────────────────
 
 /**
@@ -163,35 +215,24 @@ function scim_token(string $_action, array $_data = []): mixed {
     case 'add':
       $description        = htmlspecialchars(trim($_data['description'] ?? ''), ENT_QUOTES);
       $domain_restriction = !empty($_data['domain_restriction']) ? strtolower(trim($_data['domain_restriction'])) : null;
-      $template           = !empty($_data['template']) ? trim($_data['template']) : null;
+      $default_template   = !empty($_data['default_template']) ? trim($_data['default_template']) : null;
       $allow_from         = trim($_data['allow_from'] ?? '');
-
-      // Validate domain_restriction if provided
-      if ($domain_restriction !== null) {
-        $stmt = $pdo->prepare("SELECT `domain` FROM `domain` WHERE `domain` = :domain");
-        $stmt->execute([':domain' => $domain_restriction]);
-        if (!$stmt->fetch(PDO::FETCH_ASSOC)) {
-          $_SESSION['return'][] = [
-            'type' => 'danger',
-            'log'  => [__FUNCTION__, $_action],
-            'msg'  => 'scim_domain_not_found',
-          ];
-          return false;
-        }
-      }
+      [$mappers_json, $templates_json] = scim_encode_mappers($_data);
 
       $raw_token  = bin2hex(random_bytes(32));
       $token_hash = hash('sha256', $raw_token);
 
       $stmt = $pdo->prepare("INSERT INTO `scim_tokens`
-        (`description`, `token_hash`, `domain_restriction`, `template`, `allow_from`, `active`)
-        VALUES (:description, :token_hash, :domain_restriction, :template, :allow_from, '1')");
+        (`description`, `token_hash`, `domain_restriction`, `default_template`, `allow_from`, `mappers`, `templates`, `active`)
+        VALUES (:description, :token_hash, :domain_restriction, :default_template, :allow_from, :mappers, :templates, '1')");
       $stmt->execute([
         ':description'        => $description,
         ':token_hash'         => $token_hash,
         ':domain_restriction' => $domain_restriction,
-        ':template'           => $template,
+        ':default_template'   => $default_template,
         ':allow_from'         => $allow_from,
+        ':mappers'            => $mappers_json,
+        ':templates'          => $templates_json,
       ]);
 
       $id = $pdo->lastInsertId();
@@ -207,35 +248,28 @@ function scim_token(string $_action, array $_data = []): mixed {
       $id            = intval($_data['id'] ?? 0);
       $description   = htmlspecialchars(trim($_data['description'] ?? ''), ENT_QUOTES);
       $allow_from    = trim($_data['allow_from'] ?? '');
-      $active        = (isset($_data['active']) && intval($_data['active']) == 1) ? 1 : 0;
-      $template      = !empty($_data['template']) ? trim($_data['template']) : null;
+      $active           = (isset($_data['active']) && intval($_data['active']) == 1) ? 1 : 0;
+      $default_template = !empty($_data['default_template']) ? trim($_data['default_template']) : null;
+      [$mappers_json, $templates_json] = scim_encode_mappers($_data);
 
       $domain_restriction = !empty($_data['domain_restriction']) ? strtolower(trim($_data['domain_restriction'])) : null;
-      if ($domain_restriction !== null) {
-        $stmt = $pdo->prepare("SELECT `domain` FROM `domain` WHERE `domain` = :domain");
-        $stmt->execute([':domain' => $domain_restriction]);
-        if (!$stmt->fetch(PDO::FETCH_ASSOC)) {
-          $_SESSION['return'][] = [
-            'type' => 'danger',
-            'log'  => [__FUNCTION__, $_action],
-            'msg'  => 'scim_domain_not_found',
-          ];
-          return false;
-        }
-      }
 
       $stmt = $pdo->prepare("UPDATE `scim_tokens`
         SET `description` = :description,
             `domain_restriction` = :domain_restriction,
-            `template` = :template,
+            `default_template` = :default_template,
             `allow_from` = :allow_from,
+            `mappers` = :mappers,
+            `templates` = :templates,
             `active` = :active
         WHERE `id` = :id");
       $stmt->execute([
         ':description'        => $description,
         ':domain_restriction' => $domain_restriction,
-        ':template'           => $template,
+        ':default_template'   => $default_template,
         ':allow_from'         => $allow_from,
+        ':mappers'            => $mappers_json,
+        ':templates'          => $templates_json,
         ':active'             => $active,
         ':id'                 => $id,
       ]);
@@ -258,8 +292,8 @@ function scim_token(string $_action, array $_data = []): mixed {
       return true;
 
     case 'get_all':
-      $stmt = $pdo->query("SELECT `id`, `description`, `domain_restriction`, `template`,
-        `allow_from`, `skip_ip_check`, `active`, `created`, `modified`
+      $stmt = $pdo->query("SELECT `id`, `description`, `domain_restriction`, `default_template`,
+        `allow_from`, `mappers`, `templates`, `active`, `created`, `modified`
         FROM `scim_tokens` ORDER BY `created` DESC");
       return $stmt->fetchAll(PDO::FETCH_ASSOC);
   }
@@ -544,13 +578,14 @@ function scim_create_user(array $body, array $token): array {
 
   scim_setup_session();
 
-  if (!empty($token['template'])) {
+  $resolved_template = scim_resolve_template($body, $token);
+  if ($resolved_template !== null) {
     mailbox('add', 'mailbox_from_template', [
       'domain'     => $domain,
       'local_part' => $local_part,
       'name'       => $name,
       'authsource' => 'scim',
-      'template'   => $token['template'],
+      'template'   => $resolved_template,
       'active'     => $active,
     ]);
   } else {

--- a/data/web/inc/functions.scim.inc.php
+++ b/data/web/inc/functions.scim.inc.php
@@ -1,9 +1,25 @@
 <?php
 
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const SCIM_URN_USER    = 'urn:ietf:params:scim:schemas:core:2.0:User';
+const SCIM_URN_EXT     = 'urn:mailcow:params:scim:schemas:extension:mailcow:2.0:User';
+const SCIM_URN_ERROR   = 'urn:ietf:params:scim:api:messages:2.0:Error';
+const SCIM_URN_LIST    = 'urn:ietf:params:scim:api:messages:2.0:ListResponse';
+const SCIM_URN_PATCHOP = 'urn:ietf:params:scim:api:messages:2.0:PatchOp';
+const SCIM_URN_SEARCH  = 'urn:ietf:params:scim:api:messages:2.0:SearchRequest';
+const SCIM_URN_SPC     = 'urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig';
+const SCIM_URN_RTYPE   = 'urn:ietf:params:scim:schemas:core:2.0:ResourceType';
+
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function scim_log(string $priority, string $message): void {
   global $redis;
+  // functions.scim.inc.php is also loaded by the admin UI via prerequisites,
+  // where token management runs without a SCIM request context
+  if (!isset($redis) || !is_object($redis)) {
+    return;
+  }
   $redis->lPush('SCIM_LOG', json_encode([
     'time'     => time(),
     'priority' => $priority,
@@ -14,90 +30,1028 @@ function scim_log(string $priority, string $message): void {
 
 /**
  * Output a RFC 7644 §3.12 error response and exit.
+ * 401 responses always carry a WWW-Authenticate challenge (RFC 7235 §3.1 / RFC 6750 §3).
  */
-function scim_error(int $status, string $detail, string $scimType = ''): never {
+function scim_error(int $status, string $detail, string $scimType = '', array $headers = []): never {
+  // Log every error response. Without this an error is invisible in SCIM_LOG —
+  // only the incoming request line appears, with no outcome — which makes a
+  // failing provisioning run impossible to diagnose from the mailcow side.
+  scim_log('err', ($_SERVER['REQUEST_METHOD'] ?? '?') . ' ' . ($_SERVER['REQUEST_URI'] ?? '?')
+    . ' -> ' . $status . ($scimType !== '' ? ' ' . $scimType : '') . ': ' . $detail);
+  if (ob_get_length()) {
+    ob_clean();
+  }
+  if ($status === 401 && !preg_grep('/^WWW-Authenticate:/i', $headers)) {
+    $headers[] = 'WWW-Authenticate: Bearer realm="mailcow SCIM"';
+  }
   http_response_code($status);
+  foreach ($headers as $h) {
+    header($h);
+  }
   $body = [
-    'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+    'schemas' => [SCIM_URN_ERROR],
     'status'  => (string) $status,
     'detail'  => $detail,
   ];
   if ($scimType !== '') {
     $body['scimType'] = $scimType;
   }
-  echo json_encode($body);
+  echo json_encode($body, JSON_UNESCAPED_SLASHES);
   exit;
 }
 
 /**
- * Map a mailbox DB row + optional externalId to a SCIM User object.
+ * Emit a SCIM response and exit. Content-Type is set globally by scim.php.
  */
-function scim_user_to_response(array $row, ?string $external_id): array {
-  $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
-  $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
-  $location = $scheme . '://' . $host . '/scim/v2/Users/' . rawurlencode($row['username']);
+function scim_respond(?array $body, int $status = 200, array $headers = []): never {
+  if (ob_get_length()) {
+    ob_clean();
+  }
+  http_response_code($status);
+  foreach ($headers as $h) {
+    header($h);
+  }
+  if ($body !== null) {
+    echo json_encode($body, JSON_UNESCAPED_SLASHES);
+  }
+  exit;
+}
 
-  $name_parts = explode(' ', $row['name'] ?? '', 2);
+/**
+ * RFC 7643 §2.1: attribute names are case-insensitive.
+ * Normalize all object keys in a decoded request body to lowercase so lookups
+ * ("userName" vs "username" vs "USERNAME") behave identically.
+ */
+function scim_lower_keys(mixed $data): mixed {
+  if (!is_array($data)) {
+    return $data;
+  }
+  $out = [];
+  foreach ($data as $k => $v) {
+    $out[is_string($k) ? strtolower($k) : $k] = scim_lower_keys($v);
+  }
+  return $out;
+}
+
+/**
+ * Case-insensitive key lookup in an associative array.
+ */
+function scim_ci_get(array $arr, string $key): mixed {
+  if (array_key_exists($key, $arr)) {
+    return $arr[$key];
+  }
+  foreach ($arr as $k => $v) {
+    if (is_string($k) && strcasecmp($k, $key) === 0) {
+      return $v;
+    }
+  }
+  return null;
+}
+
+/**
+ * Strict-ish boolean coercion for SCIM boolean attributes. Accepts real
+ * booleans, 0/1, and the string forms IdPs actually send (Entra ID emits
+ * "True"/"False"). Anything else is a 400 — a blind (bool) cast would turn
+ * the string "False" into true and silently leave deactivated users active.
+ */
+function scim_to_bool(mixed $value, string $attr = 'active'): bool {
+  if (is_bool($value)) {
+    return $value;
+  }
+  if (is_int($value) && ($value === 0 || $value === 1)) {
+    return $value === 1;
+  }
+  if (is_string($value)) {
+    $v = strtolower(trim($value));
+    if ($v === 'true' || $v === '1') {
+      return true;
+    }
+    if ($v === 'false' || $v === '0') {
+      return false;
+    }
+  }
+  scim_error(400, "'$attr' must be a boolean", 'invalidValue');
+}
+
+/**
+ * Read and validate the JSON request body (RFC 7644 §3.1).
+ * - Wrong Content-Type → 415
+ * - Missing or malformed JSON → 400 invalidSyntax
+ * Returns the body with all keys lowercased.
+ */
+function scim_read_body(): array {
+  $ct = $_SERVER['CONTENT_TYPE'] ?? $_SERVER['HTTP_CONTENT_TYPE'] ?? '';
+  if ($ct !== '') {
+    $mime = strtolower(trim(explode(';', $ct)[0]));
+    if (!in_array($mime, ['application/scim+json', 'application/json'], true)) {
+      scim_error(415, "Unsupported media type '$mime'; use application/scim+json");
+    }
+  }
+  $raw = file_get_contents('php://input');
+  if (trim((string) $raw) === '') {
+    scim_error(400, 'Request body is required', 'invalidSyntax');
+  }
+  $decoded = json_decode($raw, true);
+  if (!is_array($decoded)) {
+    scim_error(400, 'Request body is not valid JSON', 'invalidSyntax');
+  }
+  return scim_lower_keys($decoded);
+}
+
+/**
+ * Require the request body to declare a schema URN (RFC 7644 §3.1).
+ */
+function scim_require_schema(array $body, string $urn): void {
+  $schemas = $body['schemas'] ?? null;
+  if (!is_array($schemas)) {
+    scim_error(400, "'schemas' attribute is required", 'invalidSyntax');
+  }
+  foreach ($schemas as $s) {
+    if (is_string($s) && strcasecmp($s, $urn) === 0) {
+      return;
+    }
+  }
+  scim_error(400, "'schemas' must include '$urn'", 'invalidValue');
+}
+
+function scim_uuid_v4(): string {
+  $b = random_bytes(16);
+  $b[6] = chr((ord($b[6]) & 0x0f) | 0x40);
+  $b[8] = chr((ord($b[8]) & 0x3f) | 0x80);
+  $hex = bin2hex($b);
+  return sprintf('%s-%s-%s-%s-%s',
+    substr($hex, 0, 8), substr($hex, 8, 4), substr($hex, 12, 4),
+    substr($hex, 16, 4), substr($hex, 20, 12));
+}
+
+/**
+ * Canonical base URL for SCIM resources. Uses MAILCOW_HOSTNAME rather than the
+ * client-controlled Host header.
+ */
+function scim_base_url(): string {
+  $host = getenv('MAILCOW_HOSTNAME');
+  if (empty($host)) {
+    $host = $_SERVER['SERVER_NAME'] ?? 'localhost';
+  }
+  $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+  return $scheme . '://' . $host . '/scim/v2';
+}
+
+// ─── Identity mapping (scim_maps: one row per SCIM-managed mailbox) ──────────
+
+/**
+ * Fetch (or lazily create) the scim_maps identity row for a mailbox.
+ */
+function scim_ensure_map(string $username, ?int $token_id): array {
+  global $pdo;
+  $stmt = $pdo->prepare("SELECT * FROM `scim_maps` WHERE `username` = :username");
+  $stmt->execute([':username' => $username]);
+  $row = $stmt->fetch(PDO::FETCH_ASSOC);
+  if ($row && !empty($row['scim_id'])) {
+    return $row;
+  }
+  $scim_id = scim_uuid_v4();
+  try {
+    if ($row) {
+      // Legacy row created before scim_id existed — backfill it
+      $stmt = $pdo->prepare("UPDATE `scim_maps` SET `scim_id` = :sid WHERE `username` = :username");
+      $stmt->execute([':sid' => $scim_id, ':username' => $username]);
+    } else {
+      $stmt = $pdo->prepare("INSERT INTO `scim_maps` (`scim_id`, `username`, `token_id`) VALUES (:sid, :username, :tid)");
+      $stmt->execute([':sid' => $scim_id, ':username' => $username, ':tid' => $token_id]);
+    }
+  } catch (PDOException $e) {
+    // Lost a race against a concurrent request — fall through to re-select
+  }
+  $stmt = $pdo->prepare("SELECT * FROM `scim_maps` WHERE `username` = :username");
+  $stmt->execute([':username' => $username]);
+  return $stmt->fetch(PDO::FETCH_ASSOC) ?: ['scim_id' => $scim_id, 'username' => $username, 'external_id' => null, 'template' => null];
+}
+
+/**
+ * Fetch a mailbox row (joined with its identity row) by SCIM id.
+ * Returns null when not found or outside the token's domain restriction —
+ * callers translate that to 404 so out-of-scope resources are indistinguishable
+ * from nonexistent ones.
+ */
+function scim_fetch_row_by_scim_id(string $scim_id, array $token): ?array {
+  global $pdo;
+  $stmt = $pdo->prepare(
+    "SELECT m.*, sm.scim_id, sm.external_id, sm.template AS scim_template
+     FROM `scim_maps` sm
+     INNER JOIN `mailbox` m ON m.username = sm.username
+     WHERE sm.scim_id = :sid AND m.authsource = 'scim'"
+  );
+  $stmt->execute([':sid' => $scim_id]);
+  $row = $stmt->fetch(PDO::FETCH_ASSOC);
+  if (!$row) {
+    return null;
+  }
+  if (!empty($token['domain_restriction']) && strcasecmp($row['domain'], $token['domain_restriction']) !== 0) {
+    return null;
+  }
+  return $row;
+}
+
+// ─── Representation ─────────────────────────────────────────────────────────
+
+/**
+ * Map a mailbox DB row (joined with scim_maps) to a SCIM User resource.
+ */
+function scim_user_to_response(array $row): array {
+  $name_parts = explode(' ', trim($row['name'] ?? ''), 2);
   $given  = $name_parts[0] ?? '';
   $family = $name_parts[1] ?? '';
 
+  $schemas = [SCIM_URN_USER];
   $obj = [
-    'schemas'     => ['urn:ietf:params:scim:schemas:core:2.0:User'],
-    'id'          => $row['username'],
-    'userName'    => $row['username'],
-    'displayName' => $row['name'] ?? '',
-    'name'        => [
-      'formatted'  => $row['name'] ?? '',
-      'givenName'  => $given,
-      'familyName' => $family,
-    ],
-    'active' => (bool)(int)$row['active'],
-    'emails' => [
-      ['value' => $row['username'], 'primary' => true],
-    ],
-    'meta' => [
-      'resourceType' => 'User',
-      'created'      => isset($row['created'])
-        ? (new DateTime($row['created']))->format(DateTime::RFC3339)
-        : null,
-      'lastModified' => !empty($row['modified'])
-        ? (new DateTime($row['modified']))->format(DateTime::RFC3339)
-        : null,
-      'location'     => $location,
-    ],
+    'schemas'  => $schemas,
+    'id'       => $row['scim_id'],
+    'userName' => $row['username'],
+  ];
+  if (!empty($row['external_id'])) {
+    $obj['externalId'] = $row['external_id'];
+  }
+  $obj['displayName'] = $row['name'] ?? '';
+  $obj['name'] = [
+    'formatted'  => $row['name'] ?? '',
+    'givenName'  => $given,
+    'familyName' => $family,
+  ];
+  $obj['active'] = (bool) (int) $row['active'];
+  $obj['emails'] = [
+    ['value' => $row['username'], 'type' => 'work', 'primary' => true],
   ];
 
-  if ($external_id !== null) {
-    $obj['externalId'] = $external_id;
+  if (!empty($row['scim_template'])) {
+    $obj['schemas'][] = SCIM_URN_EXT;
+    $obj[SCIM_URN_EXT] = ['template' => $row['scim_template']];
   }
+
+  $meta = [
+    'resourceType' => 'User',
+    'location'     => scim_base_url() . '/Users/' . rawurlencode($row['scim_id']),
+  ];
+  if (!empty($row['created'])) {
+    $meta['created'] = (new DateTime($row['created']))->format(DateTime::RFC3339);
+  }
+  if (!empty($row['modified'])) {
+    $meta['lastModified'] = (new DateTime($row['modified']))->format(DateTime::RFC3339);
+  }
+  $obj['meta'] = $meta;
 
   return $obj;
 }
 
 /**
- * Resolve display name from a SCIM User request body.
+ * Resolve display name from a (key-lowercased) SCIM User request body.
  * Priority: displayName > name.formatted > givenName+familyName > local part of userName
  */
 function scim_resolve_name(array $body): string {
-  if (!empty($body['displayName'])) {
-    return trim($body['displayName']);
+  if (!empty($body['displayname']) && is_string($body['displayname'])) {
+    return trim($body['displayname']);
   }
-  if (!empty($body['name']['formatted'])) {
-    return trim($body['name']['formatted']);
+  $name = is_array($body['name'] ?? null) ? $body['name'] : [];
+  if (!empty($name['formatted']) && is_string($name['formatted'])) {
+    return trim($name['formatted']);
   }
-  $given  = trim($body['name']['givenName'] ?? '');
-  $family = trim($body['name']['familyName'] ?? '');
+  $given  = trim((string) ($name['givenname'] ?? ''));
+  $family = trim((string) ($name['familyname'] ?? ''));
   if ($given !== '' || $family !== '') {
     return trim("$given $family");
   }
-  // fallback to local part of userName
-  $userName = $body['userName'] ?? '';
+  $userName = (string) ($body['username'] ?? '');
   return strstr($userName, '@', true) ?: $userName;
 }
 
+// ─── Attribute registry / paths ─────────────────────────────────────────────
+
 /**
- * Set up admin session so mailbox() calls have the required ACLs.
- * Mirrors the pattern in keycloak-sync.php.
+ * Known attributes of our User representation, lowercased.
+ * Value = list of sub-attributes ([] = none / not complex).
+ */
+function scim_known_attrs(): array {
+  return [
+    'schemas'     => [],
+    'id'          => [],
+    'externalid'  => [],
+    'username'    => [],
+    'displayname' => [],
+    'active'      => [],
+    'name'        => ['formatted', 'givenname', 'familyname'],
+    'emails'      => ['value', 'type', 'primary'],
+    'meta'        => ['resourcetype', 'created', 'lastmodified', 'location'],
+  ];
+}
+
+/**
+ * Split an attribute specifier ("userName", "name.givenName",
+ * "urn:...:User:userName", "urn:mailcow:...:User:template") into
+ * ['urn' => 'core'|'ext', 'parts' => [lowercased path segments]].
+ * Returns null for unknown URNs.
+ */
+function scim_split_attr(string $word): ?array {
+  $lower = strtolower($word);
+  $core_prefix = strtolower(SCIM_URN_USER) . ':';
+  $ext_prefix  = strtolower(SCIM_URN_EXT) . ':';
+  if ($lower === strtolower(SCIM_URN_EXT)) {
+    return ['urn' => 'ext', 'parts' => []];
+  }
+  if ($lower === strtolower(SCIM_URN_USER)) {
+    return ['urn' => 'core', 'parts' => []];
+  }
+  if (str_starts_with($lower, $core_prefix)) {
+    $rest = substr($lower, strlen($core_prefix));
+    $urn = 'core';
+  } elseif (str_starts_with($lower, $ext_prefix)) {
+    $rest = substr($lower, strlen($ext_prefix));
+    $urn = 'ext';
+  } elseif (str_contains($lower, ':')) {
+    return null; // unknown URN
+  } else {
+    $rest = $lower;
+    $urn = 'core';
+  }
+  $parts = $rest === '' ? [] : explode('.', $rest);
+  return ['urn' => $urn, 'parts' => $parts];
+}
+
+/**
+ * Validate a split attribute spec against the registry.
+ */
+function scim_attr_is_known(array $spec): bool {
+  if ($spec['urn'] === 'ext') {
+    return $spec['parts'] === [] || $spec['parts'] === ['template'];
+  }
+  $known = scim_known_attrs();
+  $parts = $spec['parts'];
+  if (count($parts) === 0 || count($parts) > 2) {
+    return false;
+  }
+  if (!array_key_exists($parts[0], $known)) {
+    return false;
+  }
+  if (count($parts) === 2 && !in_array($parts[1], $known[$parts[0]], true)) {
+    return false;
+  }
+  return true;
+}
+
+// ─── Filter parser (RFC 7644 §3.4.2.2 grammar) ──────────────────────────────
+
+/**
+ * Tokenize a SCIM filter / PATCH path expression.
+ * Throws RuntimeException on lexical errors (callers map to invalidFilter/invalidPath).
+ */
+function scim_filter_tokenize(string $s): array {
+  $tokens = [];
+  $i = 0;
+  $n = strlen($s);
+  while ($i < $n) {
+    $c = $s[$i];
+    if (ctype_space($c)) { $i++; continue; }
+    if (in_array($c, ['(', ')', '[', ']'], true)) {
+      $tokens[] = ['t' => $c, 'v' => null];
+      $i++;
+      continue;
+    }
+    if ($c === '"') {
+      $j = $i + 1;
+      while ($j < $n) {
+        if ($s[$j] === '\\') { $j += 2; continue; }
+        if ($s[$j] === '"') { break; }
+        $j++;
+      }
+      if ($j >= $n) {
+        throw new RuntimeException('Unterminated string literal');
+      }
+      $lit = substr($s, $i, $j - $i + 1);
+      $val = json_decode($lit);
+      if (!is_string($val)) {
+        throw new RuntimeException('Invalid string literal');
+      }
+      $tokens[] = ['t' => 'str', 'v' => $val];
+      $i = $j + 1;
+      continue;
+    }
+    $j = $i;
+    while ($j < $n && !ctype_space($s[$j]) && !in_array($s[$j], ['(', ')', '[', ']', '"'], true)) {
+      $j++;
+    }
+    $tokens[] = ['t' => 'word', 'v' => substr($s, $i, $j - $i)];
+    $i = $j;
+  }
+  return $tokens;
+}
+
+/**
+ * Recursive-descent parser producing an AST.
+ * Node shapes:
+ *   ['op'=>'or'|'and', 'l'=>node, 'r'=>node]
+ *   ['op'=>'not', 'f'=>node]
+ *   ['op'=>'pr',  'attr'=>spec]
+ *   ['op'=>'cmp', 'attr'=>spec, 'cmp'=>string, 'val'=>mixed]
+ *   ['op'=>'valpath', 'attr'=>spec, 'filter'=>node, 'sub'=>?string, 'cmp'=>?string, 'val'=>mixed, 'pr'=>bool]
+ *
+ * $ctx: when non-null, we're inside a valuePath's brackets — attribute names
+ * resolve as sub-attributes of $ctx and nested valuePaths are rejected.
+ */
+function scim_filter_parse(array $tokens, int &$pos, ?string $ctx = null): array {
+  $node = scim_filter_parse_and($tokens, $pos, $ctx);
+  while (isset($tokens[$pos]) && $tokens[$pos]['t'] === 'word' && strcasecmp($tokens[$pos]['v'], 'or') === 0) {
+    $pos++;
+    $right = scim_filter_parse_and($tokens, $pos, $ctx);
+    $node = ['op' => 'or', 'l' => $node, 'r' => $right];
+  }
+  return $node;
+}
+
+function scim_filter_parse_and(array $tokens, int &$pos, ?string $ctx): array {
+  $node = scim_filter_parse_unary($tokens, $pos, $ctx);
+  while (isset($tokens[$pos]) && $tokens[$pos]['t'] === 'word' && strcasecmp($tokens[$pos]['v'], 'and') === 0) {
+    $pos++;
+    $right = scim_filter_parse_unary($tokens, $pos, $ctx);
+    $node = ['op' => 'and', 'l' => $node, 'r' => $right];
+  }
+  return $node;
+}
+
+function scim_filter_parse_unary(array $tokens, int &$pos, ?string $ctx): array {
+  $tok = $tokens[$pos] ?? null;
+  if ($tok !== null && $tok['t'] === 'word' && strcasecmp($tok['v'], 'not') === 0
+      && isset($tokens[$pos + 1]) && $tokens[$pos + 1]['t'] === '(') {
+    $pos += 2;
+    $inner = scim_filter_parse($tokens, $pos, $ctx);
+    if (!isset($tokens[$pos]) || $tokens[$pos]['t'] !== ')') {
+      throw new RuntimeException("Expected ')' after not(...)");
+    }
+    $pos++;
+    return ['op' => 'not', 'f' => $inner];
+  }
+  if ($tok !== null && $tok['t'] === '(') {
+    $pos++;
+    $inner = scim_filter_parse($tokens, $pos, $ctx);
+    if (!isset($tokens[$pos]) || $tokens[$pos]['t'] !== ')') {
+      throw new RuntimeException("Expected ')'");
+    }
+    $pos++;
+    return $inner;
+  }
+  return scim_filter_parse_attrexp($tokens, $pos, $ctx);
+}
+
+function scim_filter_parse_attrexp(array $tokens, int &$pos, ?string $ctx): array {
+  $tok = $tokens[$pos] ?? null;
+  if ($tok === null || $tok['t'] !== 'word') {
+    throw new RuntimeException('Expected attribute expression');
+  }
+  $pos++;
+  $attr_word = $tok['v'];
+
+  if ($ctx !== null) {
+    // Inside valuePath brackets: names are sub-attributes of the parent
+    $spec = scim_split_attr($ctx . '.' . $attr_word);
+    if ($spec === null || !scim_attr_is_known($spec)) {
+      throw new RuntimeException("Unknown attribute '$attr_word'");
+    }
+    // Evaluation happens against each item of the multi-valued attribute,
+    // so the resolved path must be relative to the item
+    $spec['parts'] = array_slice($spec['parts'], 1);
+  } else {
+    $spec = scim_split_attr($attr_word);
+    if ($spec === null || !scim_attr_is_known($spec)) {
+      throw new RuntimeException("Unknown attribute '$attr_word'");
+    }
+  }
+
+  // valuePath: attrPath "[" valFilter "]" — optionally followed by
+  // ".sub op value" (not in the strict grammar, but emitted by Entra ID)
+  if ($ctx === null && isset($tokens[$pos]) && $tokens[$pos]['t'] === '[') {
+    if ($spec['urn'] !== 'core' || $spec['parts'] !== ['emails']) {
+      throw new RuntimeException("Attribute '$attr_word' does not support value filters");
+    }
+    $pos++;
+    $inner = scim_filter_parse($tokens, $pos, $spec['parts'][0]);
+    if (!isset($tokens[$pos]) || $tokens[$pos]['t'] !== ']') {
+      throw new RuntimeException("Expected ']'");
+    }
+    $pos++;
+    $node = ['op' => 'valpath', 'attr' => $spec, 'filter' => $inner, 'sub' => null, 'cmp' => null, 'val' => null, 'pr' => false];
+    // Lenient extension: emails[type eq "work"].value eq "x"
+    if (isset($tokens[$pos]) && $tokens[$pos]['t'] === 'word' && str_starts_with($tokens[$pos]['v'], '.')) {
+      $sub = strtolower(substr($tokens[$pos]['v'], 1));
+      $subspec = scim_split_attr($spec['parts'][0] . '.' . $sub);
+      if ($subspec === null || !scim_attr_is_known($subspec)) {
+        throw new RuntimeException("Unknown sub-attribute '$sub'");
+      }
+      $pos++;
+      $node['sub'] = $sub;
+      [$cmp, $val, $pr] = scim_filter_parse_op($tokens, $pos);
+      $node['cmp'] = $cmp;
+      $node['val'] = $val;
+      $node['pr']  = $pr;
+    }
+    return $node;
+  }
+
+  [$cmp, $val, $pr] = scim_filter_parse_op($tokens, $pos);
+  if ($pr) {
+    return ['op' => 'pr', 'attr' => $spec];
+  }
+  return ['op' => 'cmp', 'attr' => $spec, 'cmp' => $cmp, 'val' => $val];
+}
+
+/**
+ * Parse "pr" or "<compareOp> <compValue>". Returns [op, value, isPr].
+ */
+function scim_filter_parse_op(array $tokens, int &$pos): array {
+  $tok = $tokens[$pos] ?? null;
+  if ($tok === null || $tok['t'] !== 'word') {
+    throw new RuntimeException('Expected operator');
+  }
+  $op = strtolower($tok['v']);
+  $pos++;
+  if ($op === 'pr') {
+    return ['pr', null, true];
+  }
+  if (!in_array($op, ['eq', 'ne', 'co', 'sw', 'ew', 'gt', 'ge', 'lt', 'le'], true)) {
+    throw new RuntimeException("Unknown operator '$op'");
+  }
+  $vtok = $tokens[$pos] ?? null;
+  if ($vtok === null) {
+    throw new RuntimeException('Expected comparison value');
+  }
+  $pos++;
+  if ($vtok['t'] === 'str') {
+    return [$op, $vtok['v'], false];
+  }
+  if ($vtok['t'] === 'word') {
+    $w = strtolower($vtok['v']);
+    if ($w === 'true')  { return [$op, true, false]; }
+    if ($w === 'false') { return [$op, false, false]; }
+    if ($w === 'null')  { return [$op, null, false]; }
+    if (is_numeric($vtok['v'])) {
+      return [$op, $vtok['v'] + 0, false];
+    }
+  }
+  throw new RuntimeException('Invalid comparison value');
+}
+
+/**
+ * Parse a full filter string → AST. Exits with 400 invalidFilter on error.
+ */
+function scim_parse_filter(string $filter): array {
+  try {
+    $tokens = scim_filter_tokenize($filter);
+    if (empty($tokens)) {
+      throw new RuntimeException('Empty filter');
+    }
+    $pos = 0;
+    $ast = scim_filter_parse($tokens, $pos);
+    if ($pos !== count($tokens)) {
+      throw new RuntimeException('Unexpected trailing tokens in filter');
+    }
+    return $ast;
+  } catch (RuntimeException $e) {
+    scim_error(400, 'Invalid filter: ' . $e->getMessage(), 'invalidFilter');
+  }
+}
+
+// ─── Filter evaluation ──────────────────────────────────────────────────────
+
+/**
+ * Resolve an attribute spec against a resource → flat list of values.
+ */
+function scim_resolve_values(array $spec, array $resource): array {
+  if ($spec['urn'] === 'ext') {
+    $node = scim_ci_get($resource, SCIM_URN_EXT);
+    if (!is_array($node)) {
+      return [];
+    }
+    if ($spec['parts'] === []) {
+      return [$node];
+    }
+  } else {
+    $node = $resource;
+  }
+  foreach ($spec['parts'] as $part) {
+    if (is_array($node) && array_is_list($node)) {
+      $collected = [];
+      foreach ($node as $item) {
+        if (is_array($item)) {
+          $v = scim_ci_get($item, $part);
+          if ($v !== null) {
+            $collected[] = $v;
+          }
+        }
+      }
+      $node = $collected;
+      continue;
+    }
+    if (!is_array($node)) {
+      return [];
+    }
+    $node = scim_ci_get($node, $part);
+    if ($node === null) {
+      return [];
+    }
+  }
+  if (is_array($node) && array_is_list($node)) {
+    return $node;
+  }
+  return [$node];
+}
+
+/**
+ * Compare one actual value against a filter literal.
+ */
+function scim_compare_value(string $op, mixed $actual, mixed $expected): bool {
+  // Complex value: RFC 7644 §3.4.2.2 — compare against its "value" sub-attribute
+  if (is_array($actual)) {
+    $actual = scim_ci_get($actual, 'value');
+    if ($actual === null) {
+      return false;
+    }
+  }
+  if ($expected === null) {
+    return match ($op) {
+      'eq' => $actual === null,
+      'ne' => $actual !== null,
+      default => false,
+    };
+  }
+  if (is_bool($expected) || is_bool($actual)) {
+    // Only true/false (and their string spellings) may match a boolean
+    // attribute — (bool)"false" === true would invert the filter
+    $to_bool = static function ($v): ?bool {
+      if (is_bool($v)) {
+        return $v;
+      }
+      if (is_string($v)) {
+        if (strcasecmp($v, 'true') === 0) {
+          return true;
+        }
+        if (strcasecmp($v, 'false') === 0) {
+          return false;
+        }
+      }
+      return null;
+    };
+    $a = $to_bool($actual);
+    $e = $to_bool($expected);
+    if ($a === null || $e === null) {
+      return false;
+    }
+    return match ($op) {
+      'eq' => $a === $e,
+      'ne' => $a !== $e,
+      default => false,
+    };
+  }
+  if (is_int($expected) || is_float($expected)) {
+    if (!is_numeric($actual)) {
+      return false;
+    }
+    $a = (float) $actual;
+    $e = (float) $expected;
+    return match ($op) {
+      'eq' => $a == $e,
+      'ne' => $a != $e,
+      'gt' => $a > $e,
+      'ge' => $a >= $e,
+      'lt' => $a < $e,
+      'le' => $a <= $e,
+      default => false,
+    };
+  }
+  // String comparison — all our string attributes are caseExact=false
+  $a = (string) $actual;
+  $e = (string) $expected;
+  // DateTime values compare as instants, not lexically — the server emits
+  // '+00:00' offsets while clients typically send 'Z'
+  if ($op !== 'co' && $op !== 'sw' && $op !== 'ew'
+      && preg_match('/^\d{4}-\d{2}-\d{2}T/', $a) && preg_match('/^\d{4}-\d{2}-\d{2}T/', $e)) {
+    $ta = strtotime($a);
+    $te = strtotime($e);
+    if ($ta !== false && $te !== false) {
+      return match ($op) {
+        'eq' => $ta === $te,
+        'ne' => $ta !== $te,
+        'gt' => $ta > $te,
+        'ge' => $ta >= $te,
+        'lt' => $ta < $te,
+        'le' => $ta <= $te,
+        default => false,
+      };
+    }
+  }
+  return match ($op) {
+    'eq' => strcasecmp($a, $e) === 0,
+    'ne' => strcasecmp($a, $e) !== 0,
+    'co' => $e === '' || stripos($a, $e) !== false,
+    'sw' => $e === '' || stripos($a, $e) === 0,
+    'ew' => $e === '' || (strlen($a) >= strlen($e) && strcasecmp(substr($a, -strlen($e)), $e) === 0),
+    'gt' => strcasecmp($a, $e) > 0,
+    'ge' => strcasecmp($a, $e) >= 0,
+    'lt' => strcasecmp($a, $e) < 0,
+    'le' => strcasecmp($a, $e) <= 0,
+    default => false,
+  };
+}
+
+function scim_filter_eval(array $node, array $resource): bool {
+  switch ($node['op']) {
+    case 'or':
+      return scim_filter_eval($node['l'], $resource) || scim_filter_eval($node['r'], $resource);
+    case 'and':
+      return scim_filter_eval($node['l'], $resource) && scim_filter_eval($node['r'], $resource);
+    case 'not':
+      return !scim_filter_eval($node['f'], $resource);
+    case 'pr':
+      $values = scim_resolve_values($node['attr'], $resource);
+      foreach ($values as $v) {
+        if ($v !== null && $v !== '' && $v !== []) {
+          return true;
+        }
+      }
+      return false;
+    case 'cmp':
+      $values = scim_resolve_values($node['attr'], $resource);
+      foreach ($values as $v) {
+        if (scim_compare_value($node['cmp'], $v, $node['val'])) {
+          return true;
+        }
+      }
+      return false;
+    case 'valpath':
+      $items = scim_resolve_values($node['attr'], $resource);
+      $matched = [];
+      foreach ($items as $item) {
+        if (is_array($item) && scim_filter_eval($node['filter'], $item)) {
+          $matched[] = $item;
+        }
+      }
+      if ($node['sub'] === null) {
+        return count($matched) > 0;
+      }
+      foreach ($matched as $item) {
+        $v = scim_ci_get($item, $node['sub']);
+        if ($node['pr']) {
+          if ($v !== null && $v !== '') {
+            return true;
+          }
+        } elseif (scim_compare_value($node['cmp'], $v, $node['val'])) {
+          return true;
+        }
+      }
+      return false;
+  }
+  return false;
+}
+
+// ─── PATCH path parser (RFC 7644 §3.5.2: path = attrPath / valuePath [subAttr]) ──
+
+/**
+ * Parse a PATCH "path" → ['spec'=>attrspec, 'filter'=>?node, 'sub'=>?string].
+ * Exits with 400 invalidPath on error.
+ */
+function scim_parse_path(string $path): array {
+  try {
+    $tokens = scim_filter_tokenize($path);
+    if (empty($tokens) || $tokens[0]['t'] !== 'word') {
+      throw new RuntimeException('Expected attribute path');
+    }
+    // Unstored-but-standard core attributes (title, phoneNumbers[...]...) are
+    // accepted and ignored rather than 400'd — see scim_ignored_attrs()
+    $base_word = strtolower($tokens[0]['v']);
+    $base_name = str_contains($base_word, ':') ? substr($base_word, strrpos($base_word, ':') + 1) : $base_word;
+    $base_name = explode('.', $base_name, 2)[0];
+    if (in_array($base_name, scim_ignored_attrs(), true)) {
+      return ['ignored' => true, 'spec' => null, 'filter' => null, 'sub' => null];
+    }
+    $spec = scim_split_attr($tokens[0]['v']);
+    if ($spec === null || !scim_attr_is_known($spec)) {
+      throw new RuntimeException("Unknown attribute '{$tokens[0]['v']}'");
+    }
+    $pos = 1;
+    $filter = null;
+    $sub = null;
+    if (isset($tokens[$pos]) && $tokens[$pos]['t'] === '[') {
+      if ($spec['urn'] !== 'core' || $spec['parts'] !== ['emails']) {
+        throw new RuntimeException('Value filters are only supported on multi-valued attributes');
+      }
+      $pos++;
+      $filter = scim_filter_parse($tokens, $pos, $spec['parts'][0]);
+      if (!isset($tokens[$pos]) || $tokens[$pos]['t'] !== ']') {
+        throw new RuntimeException("Expected ']'");
+      }
+      $pos++;
+    }
+    if (isset($tokens[$pos]) && $tokens[$pos]['t'] === 'word' && str_starts_with($tokens[$pos]['v'], '.')) {
+      $sub = strtolower(substr($tokens[$pos]['v'], 1));
+      $base = $spec['parts'][count($spec['parts']) - 1] ?? '';
+      $subspec = scim_split_attr($base . '.' . $sub);
+      if ($subspec === null || !scim_attr_is_known($subspec)) {
+        throw new RuntimeException("Unknown sub-attribute '$sub'");
+      }
+      $pos++;
+    }
+    if ($pos !== count($tokens)) {
+      throw new RuntimeException('Unexpected trailing tokens in path');
+    }
+    return ['spec' => $spec, 'filter' => $filter, 'sub' => $sub];
+  } catch (RuntimeException $e) {
+    scim_error(400, 'Invalid path: ' . $e->getMessage(), 'invalidPath');
+  }
+}
+
+// ─── Attribute projection (RFC 7644 §3.9) ───────────────────────────────────
+
+/**
+ * Parse an attributes/excludedAttributes parameter (CSV string or array of
+ * strings) into a list of attr specs. Unknown attributes are ignored.
+ */
+function scim_parse_attr_list(mixed $param): ?array {
+  if ($param === null || $param === '') {
+    return null;
+  }
+  $items = is_array($param) ? $param : explode(',', (string) $param);
+  $specs = [];
+  foreach ($items as $item) {
+    $item = trim((string) $item);
+    if ($item === '') {
+      continue;
+    }
+    $spec = scim_split_attr($item);
+    if ($spec !== null && scim_attr_is_known($spec)) {
+      $specs[] = $spec;
+    }
+  }
+  return $specs;
+}
+
+/**
+ * Apply attributes/excludedAttributes projection to a resource.
+ * "schemas" and "id" are returned=always and can never be removed.
+ */
+function scim_apply_projection(array $res, ?array $attrs, ?array $excluded): array {
+  if ($attrs !== null && $excluded !== null) {
+    scim_error(400, "'attributes' and 'excludedAttributes' are mutually exclusive", 'invalidValue');
+  }
+  if ($attrs === null && $excluded === null) {
+    return $res;
+  }
+
+  if ($attrs !== null) {
+    $out = ['schemas' => $res['schemas'], 'id' => $res['id']];
+    foreach ($attrs as $spec) {
+      if ($spec['urn'] === 'ext') {
+        $ext = scim_ci_get($res, SCIM_URN_EXT);
+        if (!is_array($ext)) {
+          continue;
+        }
+        if ($spec['parts'] === [] || $spec['parts'] === ['template']) {
+          $out[SCIM_URN_EXT] = $ext;
+        }
+        continue;
+      }
+      $parts = $spec['parts'];
+      $canonical = scim_find_key($res, $parts[0]);
+      if ($canonical === null) {
+        continue;
+      }
+      $val = $res[$canonical];
+      if (count($parts) === 1) {
+        $out[$canonical] = $val;
+        continue;
+      }
+      // sub-attribute request: name.givenName / emails.value / meta.created
+      if (is_array($val) && array_is_list($val)) {
+        $filtered = [];
+        foreach ($val as $item) {
+          if (!is_array($item)) { continue; }
+          $k = scim_find_key($item, $parts[1]);
+          if ($k !== null) {
+            $filtered[] = [$k => $item[$k]];
+          }
+        }
+        $existing = (isset($out[$canonical]) && is_array($out[$canonical])) ? $out[$canonical] : null;
+        if ($existing !== null) {
+          foreach ($filtered as $i => $item) {
+            $existing[$i] = array_merge($existing[$i] ?? [], $item);
+          }
+          $out[$canonical] = $existing;
+        } else {
+          $out[$canonical] = $filtered;
+        }
+      } elseif (is_array($val)) {
+        $k = scim_find_key($val, $parts[1]);
+        if ($k !== null) {
+          $out[$canonical] = array_merge($out[$canonical] ?? [], [$k => $val[$k]]);
+        }
+      }
+    }
+    return $out;
+  }
+
+  // excludedAttributes
+  $out = $res;
+  foreach ($excluded as $spec) {
+    if ($spec['urn'] === 'ext') {
+      $k = scim_find_key($out, SCIM_URN_EXT);
+      if ($k !== null && ($spec['parts'] === [] || $spec['parts'] === ['template'])) {
+        unset($out[$k]);
+      }
+      continue;
+    }
+    $parts = $spec['parts'];
+    if ($parts[0] === 'schemas' || $parts[0] === 'id') {
+      continue; // returned=always
+    }
+    $canonical = scim_find_key($out, $parts[0]);
+    if ($canonical === null) {
+      continue;
+    }
+    if (count($parts) === 1) {
+      unset($out[$canonical]);
+      continue;
+    }
+    $val = $out[$canonical];
+    if (is_array($val) && array_is_list($val)) {
+      foreach ($val as $i => $item) {
+        if (is_array($item)) {
+          $k = scim_find_key($item, $parts[1]);
+          if ($k !== null) {
+            unset($val[$i][$k]);
+          }
+        }
+      }
+      $out[$canonical] = array_values($val);
+    } elseif (is_array($val)) {
+      $k = scim_find_key($val, $parts[1]);
+      if ($k !== null) {
+        unset($val[$k]);
+        $out[$canonical] = $val;
+      }
+    }
+  }
+  return $out;
+}
+
+/**
+ * Find the canonical (original-case) key matching $key case-insensitively.
+ */
+function scim_find_key(array $arr, string $key): ?string {
+  if (array_key_exists($key, $arr)) {
+    return $key;
+  }
+  foreach ($arr as $k => $_) {
+    if (is_string($k) && strcasecmp($k, $key) === 0) {
+      return $k;
+    }
+  }
+  return null;
+}
+
+/**
+ * Project a resource using the request's attributes/excludedAttributes query params.
+ */
+function scim_project_from_query(array $res): array {
+  global $SCIM_QUERY;
+  $attrs = scim_parse_attr_list($SCIM_QUERY['attributes'] ?? null);
+  $excl  = scim_parse_attr_list($SCIM_QUERY['excludedattributes'] ?? null);
+  return scim_apply_projection($res, $attrs, $excl);
+}
+
+// ─── mailbox() wrapper (fails loudly instead of silently) ───────────────────
+
+/**
+ * Call mailbox() and translate any 'danger' result into a SCIM error.
+ */
+function scim_mailbox_call(string $action, string $type, array $data): void {
+  if (!isset($_SESSION['return']) || !is_array($_SESSION['return'])) {
+    $_SESSION['return'] = [];
+  }
+  $before = count($_SESSION['return']);
+  mailbox($action, $type, $data);
+  $entries = array_slice($_SESSION['return'], $before);
+  foreach ($entries as $ret) {
+    if (($ret['type'] ?? '') === 'danger') {
+      $msg = $ret['msg'] ?? 'unknown error';
+      if (is_array($msg)) {
+        $msg = implode(': ', array_map(
+          fn($x) => is_array($x) ? implode(', ', array_map('strval', $x)) : (string) $x,
+          $msg
+        ));
+      }
+      scim_error(400, 'mailcow rejected the operation: ' . $msg, 'invalidValue');
+    }
+  }
+}
+
+/**
+ * Set up admin session context so mailbox() calls have the required ACLs.
+ * $_SESSION is a plain array here — scim.php never starts a real PHP session.
  */
 function scim_setup_session(): void {
   $_SESSION['mailcow_cc_username']         = 'SCIM';
@@ -113,56 +1067,77 @@ function scim_setup_session(): void {
   $_SESSION['access_all_exception']        = '1';
 }
 
+// ─── Template mapping ───────────────────────────────────────────────────────
+
 /**
- * Parse and JSON-encode the mappers/templates arrays from POST data.
- * Returns [mappers_json, templates_json] with only non-empty paired entries kept.
+ * Map a raw template attribute value through the token's mapper list.
+ * Returns the mapped mailbox template name, or null when no mapping matches.
  */
-function scim_encode_mappers(array $data): array {
-  $mappers_raw   = $data['mappers']   ?? [];
-  $templates_raw = $data['templates'] ?? [];
-  $mappers_raw   = is_array($mappers_raw)   ? $mappers_raw   : [$mappers_raw];
-  $templates_raw = is_array($templates_raw) ? $templates_raw : [$templates_raw];
-
-  $m = [];
-  $t = [];
-  foreach ($mappers_raw as $i => $mapper) {
-    $mapper   = trim((string)$mapper);
-    $template = trim((string)($templates_raw[$i] ?? ''));
-    if ($mapper !== '' && $template !== '') {
-      $m[] = $mapper;
-      $t[] = $template;
-    }
+function scim_map_attr_to_template(?string $attr, array $token): ?string {
+  if ($attr === null || $attr === '') {
+    return null;
   }
-
-  return [
-    count($m) > 0 ? json_encode($m) : null,
-    count($t) > 0 ? json_encode($t) : null,
-  ];
+  $mappers   = json_decode($token['mappers']   ?? '[]', true) ?? [];
+  $templates = json_decode($token['templates'] ?? '[]', true) ?? [];
+  $key = array_search($attr, $mappers, true);
+  if ($key !== false && isset($templates[$key]) && $templates[$key] !== '') {
+    return $templates[$key];
+  }
+  return null;
 }
 
 /**
- * Resolve the mailbox template for a SCIM-provisioned user.
- *
- * Checks the SCIM body for a 'mailcow_template' attribute (top-level or inside
- * the enterprise extension), then walks the token's mapper list for a match.
- * Falls back to the token-level default template, or null if none is configured.
+ * Extract the raw template attribute value from a (key-lowercased) body.
+ */
+function scim_body_template_attr(array $body): ?string {
+  $ext = $body[strtolower(SCIM_URN_EXT)] ?? null;
+  if (is_array($ext) && isset($ext['template']) && is_string($ext['template']) && trim($ext['template']) !== '') {
+    return trim($ext['template']);
+  }
+  return null;
+}
+
+/**
+ * Resolve the mailbox template for a new SCIM-provisioned user:
+ * mapped value from the extension attribute, else the token default.
  */
 function scim_resolve_template(array $body, array $token): ?string {
-  $enterprise_ext = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User';
-  $attr = $body['mailcow_template']
-       ?? $body[$enterprise_ext]['mailcow_template']
-       ?? null;
-
-  if ($attr !== null) {
-    $mappers   = json_decode($token['mappers']   ?? '[]', true) ?? [];
-    $templates = json_decode($token['templates'] ?? '[]', true) ?? [];
-    $key = array_search($attr, $mappers, true);
-    if ($key !== false && isset($templates[$key]) && $templates[$key] !== '') {
-      return $templates[$key];
-    }
+  $mapped = scim_map_attr_to_template(scim_body_template_attr($body), $token);
+  if ($mapped !== null) {
+    return $mapped;
   }
-
   return !empty($token['default_template']) ? $token['default_template'] : null;
+}
+
+/**
+ * Enforce immutability of the extension 'template' attribute on PUT/PATCH.
+ * Setting an initial value is allowed; changing an existing one is not.
+ */
+function scim_template_immutable_check(?string $attr, string $op_name, array $row, array $token): void {
+  global $pdo;
+  $stored = $row['scim_template'] ?? null;
+  if ($op_name === 'remove') {
+    if (!empty($stored)) {
+      scim_error(400, "'template' is immutable and cannot be removed", 'mutability');
+    }
+    return;
+  }
+  if ($attr === null) {
+    return; // omitted — immutable attributes retain their value
+  }
+  $resolved = scim_map_attr_to_template($attr, $token) ?? (!empty($token['default_template']) ? $token['default_template'] : null);
+  if (empty($stored)) {
+    if ($resolved !== null) {
+      $stmt = $pdo->prepare("UPDATE `scim_maps` SET `template` = :tpl WHERE `username` = :username");
+      $stmt->execute([':tpl' => $resolved, ':username' => $row['username']]);
+    }
+    return;
+  }
+  // Accept the server's own echoed resolved name as a no-op: GET→modify→PUT
+  // round-trips send back the resolved template ("Employees"), not the mapper key
+  if ($resolved !== $stored && $attr !== $stored) {
+    scim_error(400, "'template' is immutable; it is applied at creation time only", 'mutability');
+  }
 }
 
 // ─── Authentication ──────────────────────────────────────────────────────────
@@ -177,7 +1152,7 @@ function scim_authenticate(): array {
   $auth_header = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
   if (!preg_match('/^Bearer\s+(\S+)$/i', $auth_header, $m)) {
     scim_log('err', 'Authentication failed: missing or malformed Authorization header');
-    scim_error(401, 'Bearer token required');
+    scim_error(401, 'Bearer token required', '', ['WWW-Authenticate: Bearer realm="mailcow SCIM"']);
   }
 
   $raw_token  = $m[1];
@@ -190,7 +1165,7 @@ function scim_authenticate(): array {
   if (empty($token)) {
     $redis->publish('F2B_CHANNEL', 'mailcow SCIM: Invalid token from ' . ($_SERVER['REMOTE_ADDR'] ?? '?'));
     scim_log('err', 'Authentication failed: invalid or inactive token from ' . ($_SERVER['REMOTE_ADDR'] ?? '?'));
-    scim_error(401, 'Invalid or inactive token');
+    scim_error(401, 'Invalid or inactive token', '', ['WWW-Authenticate: Bearer realm="mailcow SCIM", error="invalid_token"']);
   }
 
   // IP ACL check
@@ -200,7 +1175,7 @@ function scim_authenticate(): array {
   if (!empty($allow_from) && !ip_acl($remote, $allow_from)) {
     $redis->publish('F2B_CHANNEL', 'mailcow SCIM: IP denied for token from ' . $remote);
     scim_log('err', 'Authentication failed: IP ' . $remote . ' not in allow list for token ID ' . $token['id']);
-    scim_error(401, 'IP address not allowed');
+    scim_error(401, 'IP address not allowed', '', ['WWW-Authenticate: Bearer realm="mailcow SCIM", error="invalid_token"']);
   }
 
   return $token;
@@ -208,23 +1183,60 @@ function scim_authenticate(): array {
 
 // ─── Token management (admin operations) ────────────────────────────────────
 
+/**
+ * Parse and JSON-encode the mappers/templates arrays from POST data.
+ * Returns [mappers_json, templates_json] with only non-empty paired entries kept.
+ */
+function scim_encode_mappers(array $data): array {
+  $mappers_raw   = $data['mappers']   ?? [];
+  $templates_raw = $data['templates'] ?? [];
+  // The active-toggle form re-posts the stored JSON strings; decode them so
+  // repeated round-trips stay idempotent instead of double-encoding
+  if (!is_array($mappers_raw)) {
+    $decoded = json_decode((string) $mappers_raw, true);
+    $mappers_raw = is_array($decoded) ? $decoded : [$mappers_raw];
+  }
+  if (!is_array($templates_raw)) {
+    $decoded = json_decode((string) $templates_raw, true);
+    $templates_raw = is_array($decoded) ? $decoded : [$templates_raw];
+  }
+
+  $m = [];
+  $t = [];
+  foreach ($mappers_raw as $i => $mapper) {
+    $mapper   = trim((string) $mapper);
+    $template = trim((string) ($templates_raw[$i] ?? ''));
+    if ($mapper !== '' && $template !== '') {
+      $m[] = $mapper;
+      $t[] = $template;
+    }
+  }
+
+  return [
+    count($m) > 0 ? json_encode($m) : null,
+    count($t) > 0 ? json_encode($t) : null,
+  ];
+}
+
 function scim_token(string $_action, array $_data = []): mixed {
   global $pdo;
 
   switch ($_action) {
     case 'add':
-      $description        = htmlspecialchars(trim($_data['description'] ?? ''), ENT_QUOTES);
+      // Stored raw — Twig autoescapes on output; escaping on input double-encodes on every round-trip
+      $description        = trim($_data['description'] ?? '');
       $domain_restriction = !empty($_data['domain_restriction']) ? strtolower(trim($_data['domain_restriction'])) : null;
       $default_template   = !empty($_data['default_template']) ? trim($_data['default_template']) : null;
       $allow_from         = trim($_data['allow_from'] ?? '');
+      $allow_claim        = (isset($_data['allow_claim']) && intval($_data['allow_claim']) == 1) ? 1 : 0;
       [$mappers_json, $templates_json] = scim_encode_mappers($_data);
 
       $raw_token  = bin2hex(random_bytes(32));
       $token_hash = hash('sha256', $raw_token);
 
       $stmt = $pdo->prepare("INSERT INTO `scim_tokens`
-        (`description`, `token_hash`, `domain_restriction`, `default_template`, `allow_from`, `mappers`, `templates`, `active`)
-        VALUES (:description, :token_hash, :domain_restriction, :default_template, :allow_from, :mappers, :templates, '1')");
+        (`description`, `token_hash`, `domain_restriction`, `default_template`, `allow_from`, `mappers`, `templates`, `allow_claim`, `active`)
+        VALUES (:description, :token_hash, :domain_restriction, :default_template, :allow_from, :mappers, :templates, :allow_claim, '1')");
       $stmt->execute([
         ':description'        => $description,
         ':token_hash'         => $token_hash,
@@ -233,6 +1245,7 @@ function scim_token(string $_action, array $_data = []): mixed {
         ':allow_from'         => $allow_from,
         ':mappers'            => $mappers_json,
         ':templates'          => $templates_json,
+        ':allow_claim'        => $allow_claim,
       ]);
 
       $id = $pdo->lastInsertId();
@@ -245,10 +1258,11 @@ function scim_token(string $_action, array $_data = []): mixed {
       return $raw_token;
 
     case 'edit':
-      $id            = intval($_data['id'] ?? 0);
-      $description   = htmlspecialchars(trim($_data['description'] ?? ''), ENT_QUOTES);
-      $allow_from    = trim($_data['allow_from'] ?? '');
+      $id               = intval($_data['id'] ?? 0);
+      $description      = trim($_data['description'] ?? '');
+      $allow_from       = trim($_data['allow_from'] ?? '');
       $active           = (isset($_data['active']) && intval($_data['active']) == 1) ? 1 : 0;
+      $allow_claim      = (isset($_data['allow_claim']) && intval($_data['allow_claim']) == 1) ? 1 : 0;
       $default_template = !empty($_data['default_template']) ? trim($_data['default_template']) : null;
       [$mappers_json, $templates_json] = scim_encode_mappers($_data);
 
@@ -261,6 +1275,7 @@ function scim_token(string $_action, array $_data = []): mixed {
             `allow_from` = :allow_from,
             `mappers` = :mappers,
             `templates` = :templates,
+            `allow_claim` = :allow_claim,
             `active` = :active
         WHERE `id` = :id");
       $stmt->execute([
@@ -270,6 +1285,7 @@ function scim_token(string $_action, array $_data = []): mixed {
         ':allow_from'         => $allow_from,
         ':mappers'            => $mappers_json,
         ':templates'          => $templates_json,
+        ':allow_claim'        => $allow_claim,
         ':active'             => $active,
         ':id'                 => $id,
       ]);
@@ -293,7 +1309,7 @@ function scim_token(string $_action, array $_data = []): mixed {
 
     case 'get_all':
       $stmt = $pdo->query("SELECT `id`, `description`, `domain_restriction`, `default_template`,
-        `allow_from`, `mappers`, `templates`, `active`, `created`, `modified`
+        `allow_from`, `mappers`, `templates`, `allow_claim`, `active`, `created`, `modified`
         FROM `scim_tokens` ORDER BY `created` DESC");
       return $stmt->fetchAll(PDO::FETCH_ASSOC);
   }
@@ -304,12 +1320,8 @@ function scim_token(string $_action, array $_data = []): mixed {
 // ─── Discovery endpoints ─────────────────────────────────────────────────────
 
 function scim_service_provider_config(): array {
-  $host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
-  $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
-  $base   = $scheme . '://' . $host . '/scim/v2';
-
   return [
-    'schemas'               => ['urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig'],
+    'schemas'               => [SCIM_URN_SPC],
     'documentationUri'      => '',
     'patch'                 => ['supported' => true],
     'bulk'                  => ['supported' => false, 'maxOperations' => 0, 'maxPayloadSize' => 0],
@@ -321,185 +1333,297 @@ function scim_service_provider_config(): array {
       [
         'name'        => 'OAuth Bearer Token',
         'description' => 'Authentication scheme using the OAuth Bearer Token standard',
+        'specUri'     => 'http://www.rfc-editor.org/info/rfc6750',
         'type'        => 'oauthbearertoken',
         'primary'     => true,
       ],
     ],
     'meta' => [
       'resourceType' => 'ServiceProviderConfig',
-      'location'     => $base . '/ServiceProviderConfig',
+      'location'     => scim_base_url() . '/ServiceProviderConfig',
     ],
   ];
 }
 
-function scim_schemas(): array {
-  $host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
-  $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
-  $base   = $scheme . '://' . $host . '/scim/v2';
+/**
+ * Full RFC 7643 §7 attribute metadata for the schemas we serve.
+ */
+function scim_schema_definitions(): array {
+  $base = scim_base_url();
+
+  $string_attr = function (string $name, string $description, array $overrides = []) {
+    return array_merge([
+      'name'        => $name,
+      'type'        => 'string',
+      'multiValued' => false,
+      'description' => $description,
+      'required'    => false,
+      'caseExact'   => false,
+      'mutability'  => 'readWrite',
+      'returned'    => 'default',
+      'uniqueness'  => 'none',
+    ], $overrides);
+  };
 
   $user_schema = [
-    'id'          => 'urn:ietf:params:scim:schemas:core:2.0:User',
+    'id'          => SCIM_URN_USER,
     'name'        => 'User',
-    'description' => 'User account',
+    'description' => 'User account (mapped to a mailcow mailbox)',
     'attributes'  => [
-      ['name' => 'userName',    'type' => 'string',  'required' => true,  'uniqueness' => 'server'],
-      ['name' => 'displayName', 'type' => 'string',  'required' => false, 'uniqueness' => 'none'],
-      ['name' => 'name',        'type' => 'complex', 'required' => false, 'uniqueness' => 'none',
+      $string_attr('userName',
+        'Unique identifier for the user, equal to the primary email address of the mailbox. Immutable: mailcow cannot rename mailboxes.',
+        ['required' => true, 'mutability' => 'immutable', 'uniqueness' => 'server']),
+      $string_attr('displayName',
+        'Human-readable display name. When omitted at creation time or cleared, defaults to the local part of userName.'),
+      [
+        'name'        => 'name',
+        'type'        => 'complex',
+        'multiValued' => false,
+        'description' => 'The components of the user\'s name. Stored as a single display name; givenName and familyName are derived by splitting on the first space.',
+        'required'    => false,
+        'mutability'  => 'readWrite',
+        'returned'    => 'default',
         'subAttributes' => [
-          ['name' => 'formatted',  'type' => 'string', 'required' => false],
-          ['name' => 'givenName',  'type' => 'string', 'required' => false],
-          ['name' => 'familyName', 'type' => 'string', 'required' => false],
+          $string_attr('formatted', 'Full name.'),
+          $string_attr('givenName', 'Given name (first token of the stored name).'),
+          $string_attr('familyName', 'Family name (remainder of the stored name).'),
         ],
       ],
-      ['name' => 'emails',  'type' => 'complex', 'multiValued' => true, 'required' => false],
-      ['name' => 'active',  'type' => 'boolean', 'required' => false, 'uniqueness' => 'none'],
+      [
+        'name'        => 'active',
+        'type'        => 'boolean',
+        'multiValued' => false,
+        'description' => 'Mailbox active state.',
+        'required'    => false,
+        'mutability'  => 'readWrite',
+        'returned'    => 'default',
+      ],
+      [
+        'name'        => 'emails',
+        'type'        => 'complex',
+        'multiValued' => true,
+        'description' => 'Email addresses. Read-only: derived from userName.',
+        'required'    => false,
+        'mutability'  => 'readOnly',
+        'returned'    => 'default',
+        'subAttributes' => [
+          $string_attr('value', 'Email address.', ['mutability' => 'readOnly']),
+          $string_attr('type', 'Address classification.', ['mutability' => 'readOnly', 'canonicalValues' => ['work']]),
+          [
+            'name'        => 'primary',
+            'type'        => 'boolean',
+            'multiValued' => false,
+            'description' => 'Whether this is the primary address.',
+            'required'    => false,
+            'mutability'  => 'readOnly',
+            'returned'    => 'default',
+          ],
+        ],
+      ],
     ],
     'meta' => [
       'resourceType' => 'Schema',
-      'location'     => $base . '/Schemas/urn:ietf:params:scim:schemas:core:2.0:User',
+      'location'     => $base . '/Schemas/' . SCIM_URN_USER,
     ],
   ];
 
+  $ext_schema = [
+    'id'          => SCIM_URN_EXT,
+    'name'        => 'MailcowUser',
+    'description' => 'mailcow extension attributes for SCIM-provisioned users',
+    'attributes'  => [
+      $string_attr('template',
+        'Mailbox template selector. The value is resolved through the SCIM token\'s attribute mapping to a mailcow mailbox template and applied at creation time only; responses return the resolved template name.',
+        ['mutability' => 'immutable']),
+    ],
+    'meta' => [
+      'resourceType' => 'Schema',
+      'location'     => $base . '/Schemas/' . SCIM_URN_EXT,
+    ],
+  ];
+
+  return [$user_schema, $ext_schema];
+}
+
+function scim_schemas(): array {
+  $schemas = scim_schema_definitions();
   return [
-    'schemas'     => ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
-    'totalResults' => 1,
-    'Resources'   => [$user_schema],
+    'schemas'      => [SCIM_URN_LIST],
+    'totalResults' => count($schemas),
+    'startIndex'   => 1,
+    'itemsPerPage' => count($schemas),
+    'Resources'    => $schemas,
+  ];
+}
+
+function scim_schema_by_id(string $id): ?array {
+  foreach (scim_schema_definitions() as $schema) {
+    if (strcasecmp($schema['id'], $id) === 0) {
+      return $schema;
+    }
+  }
+  return null;
+}
+
+function scim_resource_type_definitions(): array {
+  $base = scim_base_url();
+  return [
+    [
+      'schemas'          => [SCIM_URN_RTYPE],
+      'id'               => 'User',
+      'name'             => 'User',
+      'endpoint'         => '/Users',
+      'description'      => 'User account',
+      'schema'           => SCIM_URN_USER,
+      'schemaExtensions' => [
+        ['schema' => SCIM_URN_EXT, 'required' => false],
+      ],
+      'meta'             => [
+        'resourceType' => 'ResourceType',
+        'location'     => $base . '/ResourceTypes/User',
+      ],
+    ],
   ];
 }
 
 function scim_resource_types(): array {
-  $host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
-  $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
-  $base   = $scheme . '://' . $host . '/scim/v2';
-
+  $types = scim_resource_type_definitions();
   return [
-    'schemas'      => ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
-    'totalResults' => 1,
-    'Resources'    => [
-      [
-        'schemas'          => ['urn:ietf:params:scim:schemas:core:2.0:ResourceType'],
-        'id'               => 'User',
-        'name'             => 'User',
-        'endpoint'         => '/Users',
-        'description'      => 'User account',
-        'schema'           => 'urn:ietf:params:scim:schemas:core:2.0:User',
-        'schemaExtensions' => [],
-        'meta'             => [
-          'resourceType' => 'ResourceType',
-          'location'     => $base . '/ResourceTypes/User',
-        ],
-      ],
-    ],
+    'schemas'      => [SCIM_URN_LIST],
+    'totalResults' => count($types),
+    'startIndex'   => 1,
+    'itemsPerPage' => count($types),
+    'Resources'    => $types,
   ];
+}
+
+function scim_resource_type_by_id(string $id): ?array {
+  foreach (scim_resource_type_definitions() as $type) {
+    if (strcasecmp($type['id'], $id) === 0) {
+      return $type;
+    }
+  }
+  return null;
 }
 
 // ─── User operations ─────────────────────────────────────────────────────────
 
-function scim_list_users(array $token): array {
+/**
+ * Shared list/query implementation for GET /Users and POST /.search.
+ * $q keys (lowercased): filter, startindex, count, attributes, excludedattributes.
+ */
+function scim_query_users(array $token, array $q): never {
   global $pdo;
 
-  $start_index = max(1, intval($_GET['startIndex'] ?? 1));
-  $count       = min(500, max(1, intval($_GET['count'] ?? 100)));
-  $offset      = $start_index - 1;
+  $filter_str = isset($q['filter']) && $q['filter'] !== '' && $q['filter'] !== null ? (string) $q['filter'] : null;
+  $ast = $filter_str !== null ? scim_parse_filter($filter_str) : null;
 
-  // Parse simple filter: userName eq "..."
-  $filter_username = null;
-  $filter_str = $_GET['filter'] ?? '';
-  if ($filter_str !== '') {
-    if (preg_match('/^userName\s+eq\s+"([^"]+)"/i', $filter_str, $fm)) {
-      $filter_username = $fm[1];
-    } else {
-      scim_error(400, 'Only "userName eq" filter is supported', 'invalidFilter');
-    }
-  }
+  $start_index = isset($q['startindex']) ? max(1, intval($q['startindex'])) : 1;
+  // RFC 7644 §3.4.2.4: negative count → 0; count=0 returns totalResults only
+  $count = isset($q['count']) && $q['count'] !== '' && $q['count'] !== null
+    ? min(500, max(0, intval($q['count'])))
+    : 100;
 
-  $where  = ['m.authsource = \'scim\''];
+  $attrs = scim_parse_attr_list($q['attributes'] ?? null);
+  $excl  = scim_parse_attr_list($q['excludedattributes'] ?? null);
+
+  $where  = ["m.authsource = 'scim'"];
   $params = [];
-
   if (!empty($token['domain_restriction'])) {
-    $where[]                   = 'm.domain = :domain_restriction';
+    $where[] = 'm.domain = :domain_restriction';
     $params[':domain_restriction'] = $token['domain_restriction'];
   }
-  if ($filter_username !== null) {
-    $where[]             = 'm.username = :filter_username';
-    $params[':filter_username'] = $filter_username;
-  }
-
   $where_sql = implode(' AND ', $where);
 
-  // Count total
-  $count_stmt = $pdo->prepare("SELECT COUNT(*) FROM `mailbox` m WHERE $where_sql");
-  $count_stmt->execute($params);
-  $total = (int) $count_stmt->fetchColumn();
-
-  // Fetch page
-  $params[':limit']  = $count;
-  $params[':offset'] = $offset;
   $stmt = $pdo->prepare(
-    "SELECT m.*, sm.external_id
+    "SELECT m.*, sm.scim_id, sm.external_id, sm.template AS scim_template
      FROM `mailbox` m
-     LEFT JOIN `scim_maps` sm ON m.username = sm.username AND sm.token_id = :token_id
+     LEFT JOIN `scim_maps` sm ON sm.username = m.username
      WHERE $where_sql
-     ORDER BY m.username
-     LIMIT :limit OFFSET :offset"
+     ORDER BY m.username"
   );
-  $params[':token_id'] = (int) $token['id'];
-  // PDO needs int type for LIMIT/OFFSET with named params
-  $stmt->bindValue(':limit',  $count,  PDO::PARAM_INT);
-  $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
-  foreach ($params as $key => $val) {
-    if (in_array($key, [':limit', ':offset'])) continue;
-    $stmt->bindValue($key, $val);
-  }
-  $stmt->execute();
+  $stmt->execute($params);
   $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-  $resources = array_map(fn($row) => scim_user_to_response($row, $row['external_id'] ?? null), $rows);
+  // Lazily backfill identity rows for mailboxes pre-created via the admin UI
+  foreach ($rows as &$row) {
+    if (empty($row['scim_id'])) {
+      $map = scim_ensure_map($row['username'], (int) $token['id']);
+      $row['scim_id']       = $map['scim_id'];
+      $row['external_id']   = $map['external_id'] ?? null;
+      $row['scim_template'] = $map['template'] ?? null;
+    }
+  }
+  unset($row);
 
-  return [
-    'schemas'      => ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+  $resources = array_map('scim_user_to_response', $rows);
+
+  if ($ast !== null) {
+    $resources = array_values(array_filter($resources, fn($r) => scim_filter_eval($ast, $r)));
+  }
+
+  $total = count($resources);
+  $page  = $count > 0 ? array_slice($resources, $start_index - 1, $count) : [];
+  $page  = array_map(fn($r) => scim_apply_projection($r, $attrs, $excl), $page);
+
+  scim_respond([
+    'schemas'      => [SCIM_URN_LIST],
     'totalResults' => $total,
     'startIndex'   => $start_index,
-    'itemsPerPage' => count($resources),
-    'Resources'    => $resources,
-  ];
+    'itemsPerPage' => count($page),
+    'Resources'    => $page,
+  ]);
 }
 
-function scim_get_user(string $id, array $token): array {
-  global $pdo;
+/**
+ * POST /Users/.search and POST /.search (RFC 7644 §3.4.3).
+ */
+function scim_search(array $body, array $token): never {
+  scim_require_schema($body, SCIM_URN_SEARCH);
+  // sortBy/sortOrder: sorting is unsupported and declared as such — ignored per §3.4.2.3
+  scim_query_users($token, [
+    'filter'             => $body['filter'] ?? null,
+    'startindex'         => $body['startindex'] ?? null,
+    'count'              => $body['count'] ?? null,
+    'attributes'         => $body['attributes'] ?? null,
+    'excludedattributes' => $body['excludedattributes'] ?? null,
+  ]);
+}
 
-  $stmt = $pdo->prepare(
-    "SELECT m.*, sm.external_id
-     FROM `mailbox` m
-     LEFT JOIN `scim_maps` sm ON m.username = sm.username AND sm.token_id = :token_id
-     WHERE m.username = :username AND m.authsource = 'scim'"
-  );
-  $stmt->execute([':username' => $id, ':token_id' => (int) $token['id']]);
-  $row = $stmt->fetch(PDO::FETCH_ASSOC);
-
+function scim_get_user(string $scim_id, array $token): never {
+  $row = scim_fetch_row_by_scim_id($scim_id, $token);
   if (!$row) {
-    scim_error(404, 'User not found', 'notFound');
+    scim_error(404, 'User not found');
   }
-
-  if (!empty($token['domain_restriction']) && $row['domain'] !== $token['domain_restriction']) {
-    scim_error(403, 'Token is restricted to a different domain');
-  }
-
-  return scim_user_to_response($row, $row['external_id'] ?? null);
+  scim_respond(scim_project_from_query(scim_user_to_response($row)));
 }
 
-function scim_create_user(array $body, array $token): array {
+function scim_create_user(array $body, array $token): never {
   global $pdo;
 
-  $userName = trim($body['userName'] ?? '');
-  if (!filter_var($userName, FILTER_VALIDATE_EMAIL)) {
+  scim_require_schema($body, SCIM_URN_USER);
+
+  $userName = trim((string) ($body['username'] ?? ''));
+  $at = strrpos($userName, '@');
+  if ($at === false || $at === 0 || $at === strlen($userName) - 1) {
     scim_error(400, 'userName must be a valid email address', 'invalidValue');
   }
 
-  $parts      = explode('@', $userName, 2);
-  $local_part = $parts[0];
-  $domain     = strtolower($parts[1]);
+  // Normalize exactly like mailbox('add') does (functions.mailbox.inc.php),
+  // so the scim_maps row is byte-identical to the mailbox row and IDN
+  // domains resolve against their stored punycode form
+  $local_part = strtolower(substr($userName, 0, $at));
+  $domain     = idn_to_ascii(strtolower(substr($userName, $at + 1)), 0, INTL_IDNA_VARIANT_UTS46);
   $username   = $local_part . '@' . $domain;
+  if ($domain === false || !filter_var($username, FILTER_VALIDATE_EMAIL)) {
+    scim_error(400, 'userName must be a valid email address', 'invalidValue');
+  }
+
+  // Domain restriction check FIRST — a restricted token must not be able to
+  // probe which other domains exist
+  if (!empty($token['domain_restriction']) && $domain !== $token['domain_restriction']) {
+    scim_error(403, "Token is restricted to domain '{$token['domain_restriction']}'");
+  }
 
   // Validate domain exists
   $stmt = $pdo->prepare("SELECT `domain` FROM `domain` WHERE `domain` = :domain");
@@ -508,17 +1632,12 @@ function scim_create_user(array $body, array $token): array {
     scim_error(400, "Domain '$domain' does not exist in mailcow", 'invalidValue');
   }
 
-  // Domain restriction check
-  if (!empty($token['domain_restriction']) && $domain !== $token['domain_restriction']) {
-    scim_error(403, "Token is restricted to domain '{$token['domain_restriction']}'");
-  }
-
   // Duplicate check
   $stmt = $pdo->prepare("SELECT `username`, `authsource` FROM `mailbox` WHERE `username` = :username");
   $stmt->execute([':username' => $username]);
   $existing = $stmt->fetch(PDO::FETCH_ASSOC);
 
-  $external_id = $body['externalId'] ?? null;
+  $external_id = isset($body['externalid']) && $body['externalid'] !== null ? (string) $body['externalid'] : null;
 
   if ($existing) {
     if ($existing['authsource'] !== 'scim') {
@@ -527,60 +1646,84 @@ function scim_create_user(array $body, array $token): array {
         "To transfer SCIM management, change the mailbox authsource to 'scim' in the mailcow admin panel first.",
         'uniqueness');
     }
+    if (empty($token['allow_claim']) || intval($token['allow_claim']) !== 1) {
+      scim_error(409, "User '$username' already exists", 'uniqueness');
+    }
 
-    // User was pre-created with authsource='scim' (e.g. via the admin UI).
-    // Claim them: update attributes and link the externalId, then return 200.
+    // Claiming enabled for this token: adopt the pre-created mailbox
     if ($external_id !== null) {
-      // Ensure the externalId isn't already mapped to a different user
-      $stmt = $pdo->prepare("SELECT `username` FROM `scim_maps` WHERE `external_id` = :eid AND `token_id` = :tid AND `username` != :username");
-      $stmt->execute([':eid' => $external_id, ':tid' => (int) $token['id'], ':username' => $username]);
+      $stmt = $pdo->prepare("SELECT `username` FROM `scim_maps` WHERE `external_id` = :eid AND `username` != :username");
+      $stmt->execute([':eid' => $external_id, ':username' => $username]);
       if ($stmt->fetch(PDO::FETCH_ASSOC)) {
         scim_error(409, "externalId '$external_id' is already mapped to a different user", 'uniqueness');
-      }
-
-      $stmt = $pdo->prepare("SELECT `id` FROM `scim_maps` WHERE `username` = :username AND `token_id` = :tid");
-      $stmt->execute([':username' => $username, ':tid' => (int) $token['id']]);
-      if ($stmt->fetch(PDO::FETCH_ASSOC)) {
-        $stmt = $pdo->prepare("UPDATE `scim_maps` SET `external_id` = :eid WHERE `username` = :username AND `token_id` = :tid");
-        $stmt->execute([':eid' => $external_id, ':username' => $username, ':tid' => (int) $token['id']]);
-      } else {
-        $stmt = $pdo->prepare("INSERT INTO `scim_maps` (`external_id`, `username`, `token_id`) VALUES (:eid, :username, :tid)");
-        $stmt->execute([':eid' => $external_id, ':username' => $username, ':tid' => (int) $token['id']]);
       }
     }
 
     $name   = scim_resolve_name($body);
-    $active = isset($body['active']) ? (int)(bool)$body['active'] : 1;
+    $active = array_key_exists('active', $body) ? (int) scim_to_bool($body['active']) : 1;
 
     scim_setup_session();
-    mailbox('edit', 'mailbox', [
+
+    // Bring the adopted mailbox under template control, mirroring what the OIDC
+    // login flow does for an existing mailbox (functions.inc.php). mailbox()
+    // short-circuits when the template's attribute_hash and the name already
+    // match, so repeat POSTs are a no-op. This runs BEFORE the name/active edit
+    // below so the SCIM values stay authoritative over the template's own
+    // name/active. Note this overwrites quota, ACLs and protocol access on the
+    // existing mailbox with the template's values — claiming a mailbox means
+    // handing it to the IdP's template.
+    $resolved_template = scim_resolve_template($body, $token);
+    if ($resolved_template !== null) {
+      scim_mailbox_call('edit', 'mailbox_from_template', [
+        'username' => $username,
+        'name'     => $name,
+        'template' => $resolved_template,
+      ]);
+    }
+
+    scim_mailbox_call('edit', 'mailbox', [
       'username' => [$username],
       'name'     => $name,
       'active'   => $active,
     ]);
 
+    // POST is the creation of the SCIM resource even when the mailbox predates
+    // it, so the resolved template is recorded here the same way as on a native
+    // create — otherwise the extension attribute would be absent from the
+    // representation of an adopted user for no visible reason.
+    $map = scim_ensure_map($username, (int) $token['id']);
+    $stmt = $pdo->prepare("UPDATE `scim_maps` SET `template` = :tpl WHERE `username` = :username");
+    $stmt->execute([':tpl' => $resolved_template, ':username' => $username]);
+    if ($external_id !== null) {
+      $stmt = $pdo->prepare("UPDATE `scim_maps` SET `external_id` = :eid, `token_id` = :tid WHERE `username` = :username");
+      $stmt->execute([':eid' => $external_id, ':tid' => (int) $token['id'], ':username' => $username]);
+    }
+
     scim_log('info', "Claimed existing mailbox '$username' via SCIM POST (token ID {$token['id']})");
-    http_response_code(200);
-    return scim_get_user($username, $token);
+    // The SCIM resource is created at this moment (identity row minted) —
+    // RFC 7644 §3.3 requires 201 + Location even though the mailbox predated it
+    $row = scim_fetch_row_by_scim_id($map['scim_id'], $token);
+    $resource = scim_user_to_response($row);
+    scim_respond(scim_project_from_query($resource), 201, ['Location: ' . $resource['meta']['location']]);
   }
 
-  // externalId duplicate check for this token (new user path)
+  // externalId duplicate check (new user path)
   if ($external_id !== null) {
-    $stmt = $pdo->prepare("SELECT `id` FROM `scim_maps` WHERE `external_id` = :eid AND `token_id` = :tid");
-    $stmt->execute([':eid' => $external_id, ':tid' => (int) $token['id']]);
+    $stmt = $pdo->prepare("SELECT `id` FROM `scim_maps` WHERE `external_id` = :eid");
+    $stmt->execute([':eid' => $external_id]);
     if ($stmt->fetch(PDO::FETCH_ASSOC)) {
       scim_error(409, "externalId '$external_id' is already mapped to a user", 'uniqueness');
     }
   }
 
   $name   = scim_resolve_name($body);
-  $active = isset($body['active']) ? (int)(bool)$body['active'] : 1;
+  $active = array_key_exists('active', $body) ? (int) scim_to_bool($body['active']) : 1;
 
   scim_setup_session();
 
   $resolved_template = scim_resolve_template($body, $token);
   if ($resolved_template !== null) {
-    mailbox('add', 'mailbox_from_template', [
+    scim_mailbox_call('add', 'mailbox_from_template', [
       'domain'     => $domain,
       'local_part' => $local_part,
       'name'       => $name,
@@ -589,7 +1732,7 @@ function scim_create_user(array $body, array $token): array {
       'active'     => $active,
     ]);
   } else {
-    mailbox('add', 'mailbox', [
+    scim_mailbox_call('add', 'mailbox', [
       'domain'     => $domain,
       'local_part' => $local_part,
       'name'       => $name,
@@ -600,166 +1743,466 @@ function scim_create_user(array $body, array $token): array {
     ]);
   }
 
-  // Check for errors from mailbox()
-  foreach ($_SESSION['return'] as $ret) {
-    if ($ret['type'] === 'danger') {
-      $msg = is_array($ret['msg']) ? implode(': ', $ret['msg']) : $ret['msg'];
-      scim_error(400, 'Failed to create mailbox: ' . $msg, 'invalidValue');
-    }
-  }
-
-  // Insert scim_maps entry
-  if ($external_id !== null) {
-    $stmt = $pdo->prepare("INSERT INTO `scim_maps` (`external_id`, `username`, `token_id`)
-      VALUES (:eid, :username, :tid)");
-    $stmt->execute([':eid' => $external_id, ':username' => $username, ':tid' => (int) $token['id']]);
-  }
+  // Create the identity row
+  $scim_id = scim_uuid_v4();
+  $stmt = $pdo->prepare("INSERT INTO `scim_maps` (`scim_id`, `external_id`, `username`, `token_id`, `template`)
+    VALUES (:sid, :eid, :username, :tid, :tpl)");
+  $stmt->execute([
+    ':sid'      => $scim_id,
+    ':eid'      => $external_id,
+    ':username' => $username,
+    ':tid'      => (int) $token['id'],
+    ':tpl'      => $resolved_template,
+  ]);
 
   scim_log('info', "Created mailbox '$username' via SCIM (token ID {$token['id']})");
 
-  http_response_code(201);
-  return scim_get_user($username, $token);
+  $row = scim_fetch_row_by_scim_id($scim_id, $token);
+  $resource = scim_user_to_response($row);
+  scim_respond(scim_project_from_query($resource), 201, ['Location: ' . $resource['meta']['location']]);
 }
 
-function scim_replace_user(string $id, array $body, array $token): array {
+function scim_replace_user(string $scim_id, array $body, array $token): never {
   global $pdo;
 
-  // Verify user exists and belongs to this token's domain restriction
-  scim_get_user($id, $token); // exits with 404 if not found
+  $row = scim_fetch_row_by_scim_id($scim_id, $token);
+  if (!$row) {
+    scim_error(404, 'User not found');
+  }
+
+  scim_require_schema($body, SCIM_URN_USER);
+
+  // userName is required and immutable (mailcow cannot rename mailboxes)
+  $userName = trim((string) ($body['username'] ?? ''));
+  if ($userName === '') {
+    scim_error(400, 'userName is required', 'invalidValue');
+  }
+  if (strcasecmp($userName, $row['username']) !== 0) {
+    scim_error(400, 'userName is immutable: mailcow cannot rename mailboxes', 'mutability');
+  }
+
+  // 'template' extension attribute is immutable — applied at creation only
+  scim_template_immutable_check(scim_body_template_attr($body), 'replace', $row, $token);
 
   $name   = scim_resolve_name($body);
-  $active = isset($body['active']) ? (int)(bool)$body['active'] : 1;
+  $active = array_key_exists('active', $body) ? (int) scim_to_bool($body['active']) : 1;
 
   scim_setup_session();
-  mailbox('edit', 'mailbox', [
-    'username' => [$id],
+  scim_mailbox_call('edit', 'mailbox', [
+    'username' => [$row['username']],
     'name'     => $name,
     'active'   => $active,
   ]);
 
-  // Update externalId if provided
-  $external_id = $body['externalId'] ?? null;
+  // externalId: PUT is a full replace — omitted means cleared (RFC 7644 §3.5.1)
+  $external_id = isset($body['externalid']) && $body['externalid'] !== null ? (string) $body['externalid'] : null;
   if ($external_id !== null) {
-    // Check if a map entry already exists for this username
-    $stmt = $pdo->prepare("SELECT `id` FROM `scim_maps` WHERE `username` = :username");
-    $stmt->execute([':username' => $id]);
-    $existing = $stmt->fetch(PDO::FETCH_ASSOC);
-    if ($existing) {
-      $stmt = $pdo->prepare("UPDATE `scim_maps` SET `external_id` = :eid WHERE `username` = :username AND `token_id` = :tid");
-      $stmt->execute([':eid' => $external_id, ':username' => $id, ':tid' => (int) $token['id']]);
-    } else {
-      $stmt = $pdo->prepare("INSERT INTO `scim_maps` (`external_id`, `username`, `token_id`) VALUES (:eid, :username, :tid)");
-      $stmt->execute([':eid' => $external_id, ':username' => $id, ':tid' => (int) $token['id']]);
+    $stmt = $pdo->prepare("SELECT `username` FROM `scim_maps` WHERE `external_id` = :eid AND `username` != :username");
+    $stmt->execute([':eid' => $external_id, ':username' => $row['username']]);
+    if ($stmt->fetch(PDO::FETCH_ASSOC)) {
+      scim_error(409, "externalId '$external_id' is already mapped to a different user", 'uniqueness');
     }
   }
+  $stmt = $pdo->prepare("UPDATE `scim_maps` SET `external_id` = :eid WHERE `username` = :username");
+  $stmt->execute([':eid' => $external_id, ':username' => $row['username']]);
 
-  scim_log('info', "Replaced mailbox '$id' via SCIM (token ID {$token['id']})");
-  return scim_get_user($id, $token);
+  scim_log('info', "Replaced mailbox '{$row['username']}' via SCIM (token ID {$token['id']})");
+  $fresh = scim_fetch_row_by_scim_id($scim_id, $token);
+  scim_respond(scim_project_from_query(scim_user_to_response($fresh)));
 }
 
-function scim_patch_user(string $id, array $body, array $token): array {
-  global $pdo;
+// ─── PATCH ──────────────────────────────────────────────────────────────────
 
-  // Verify user exists
-  scim_get_user($id, $token);
-
-  $operations = $body['Operations'] ?? [];
-  if (empty($operations) || !is_array($operations)) {
-    scim_error(400, 'Operations array is required', 'invalidSyntax');
-  }
-
-  $update = []; // fields to update in mailbox
-
-  foreach ($operations as $op) {
-    $op_name = strtolower($op['op'] ?? '');
-    $path    = $op['path'] ?? null;
-    $value   = $op['value'] ?? null;
-
-    if (!in_array($op_name, ['add', 'replace', 'remove'])) {
-      scim_error(400, "Unsupported operation '$op_name'", 'invalidSyntax');
-    }
-
-    // Handle path-less value object (e.g., {"op":"replace","value":{"active":false}})
-    if ($path === null && is_array($value)) {
-      foreach ($value as $attr => $val) {
-        $update = array_merge($update, scim_patch_resolve_attr($attr, $val, $op_name));
-      }
-      continue;
-    }
-
-    if ($path === null) {
-      scim_error(400, 'path is required for this operation', 'invalidSyntax');
-    }
-
-    $update = array_merge($update, scim_patch_resolve_attr($path, $value, $op_name));
-  }
-
-  if (empty($update)) {
-    // No-op — return current state
-    return scim_get_user($id, $token);
-  }
-
-  scim_setup_session();
-  $edit_data = array_merge(['username' => [$id]], $update);
-  mailbox('edit', 'mailbox', $edit_data);
-
-  scim_log('info', "Patched mailbox '$id' via SCIM (token ID {$token['id']})");
-  return scim_get_user($id, $token);
+/**
+ * Set both PATCH name components from a full display name (split on first space).
+ * Tracking given/family separately (composed once at write time) keeps any op
+ * ordering within one PATCH convergent — collapsing to a single string after
+ * each op made "remove name, add familyName, add givenName" lose the family name.
+ */
+function scim_state_set_full(array &$state, string $full): void {
+  $parts = explode(' ', trim($full), 2);
+  $state['given']  = $parts[0] ?? '';
+  $state['family'] = $parts[1] ?? '';
 }
 
 /**
- * Translate a single SCIM PATCH path+value into mailbox() edit parameters.
+ * RFC 7643 core User attributes mailcow does not store. They are accepted and
+ * ignored on PATCH (mirroring POST/PUT tolerance) instead of 400 invalidPath —
+ * default Entra/Okta attribute maps (jobTitle→title, phoneNumbers, …) would
+ * otherwise create users successfully and then quarantine on every update.
+ * 'password' and 'groups' are deliberately absent: silently ignoring those
+ * would be worse than a visible error.
  */
-function scim_patch_resolve_attr(string $path, mixed $value, string $op): array {
-  $supported = [
-    'active'          => 'active',
-    'displayname'     => 'name',
-    'name.formatted'  => 'name',
-    'name.givenname'  => null, // handled specially
-    'name.familyname' => null, // handled specially
+function scim_ignored_attrs(): array {
+  return [
+    'title', 'nickname', 'profileurl', 'usertype', 'preferredlanguage',
+    'locale', 'timezone', 'phonenumbers', 'ims', 'photos', 'addresses',
+    'entitlements', 'roles', 'x509certificates',
   ];
-
-  $path_lower = strtolower($path);
-
-  if (!array_key_exists($path_lower, $supported)) {
-    scim_error(400, "Unsupported PATCH path '$path'", 'invalidPath');
-  }
-
-  if ($op === 'remove' && in_array($path_lower, ['active'])) {
-    scim_error(400, "Cannot remove required attribute '$path'", 'noTarget');
-  }
-
-  switch ($path_lower) {
-    case 'active':
-      return ['active' => (int)(bool)$value];
-    case 'displayname':
-    case 'name.formatted':
-      return ['name' => trim((string)$value)];
-    case 'name.givenname':
-    case 'name.familyname':
-      // We can only update the full name; return a placeholder that signals partial update
-      // The caller must handle this by fetching current name and merging
-      // For simplicity, if only one part is provided, use it as the full name
-      return ['name' => trim((string)$value)];
-  }
-
-  return [];
 }
 
-function scim_delete_user(string $id, array $token): void {
-  // Verify user exists (exits with 404 if not found or domain restricted)
-  scim_get_user($id, $token);
+/**
+ * Enforce read-only semantics on emails: a modification whose result equals the
+ * current derived value is a no-op; anything else is a mutability error.
+ */
+function scim_patch_check_emails(mixed $value, ?string $sub, string $op_name, array $row): void {
+  if ($op_name === 'remove') {
+    scim_error(400, "'emails' is read-only (derived from userName)", 'mutability');
+  }
+  $candidates = [];
+  if ($sub === 'value' || is_string($value)) {
+    $candidates[] = (string) $value;
+  } elseif (is_array($value)) {
+    $items = array_is_list($value) ? $value : [$value];
+    foreach ($items as $item) {
+      if (is_array($item)) {
+        $v = scim_ci_get($item, 'value');
+        if ($v !== null) {
+          $candidates[] = (string) $v;
+        }
+      } elseif (is_string($item)) {
+        $candidates[] = $item;
+      }
+    }
+  }
+  foreach ($candidates as $cand) {
+    if (strcasecmp(trim($cand), $row['username']) !== 0) {
+      scim_error(400, "'emails' is read-only (derived from userName); update userName is not supported as mailcow cannot rename mailboxes", 'mutability');
+    }
+  }
+}
+
+/**
+ * Apply one PATCH operation given as a path-less value object (keys lowercased).
+ */
+function scim_patch_apply_object(array $obj, string $op_name, array &$state, array $row, array $token): void {
+  foreach ($obj as $key => $value) {
+    if (!is_string($key)) {
+      scim_error(400, 'Invalid attribute in value object', 'invalidPath');
+    }
+    switch ($key) {
+      case 'schemas':
+        break;
+      case 'id':
+        if (!is_string($value) || strcasecmp($value, (string) $row['scim_id']) !== 0) {
+          scim_error(400, "'id' is read-only", 'mutability');
+        }
+        break;
+      case 'meta':
+        // read-only, server-controlled — ignored
+        break;
+      case 'username':
+        if (!is_string($value) || strcasecmp(trim($value), $row['username']) !== 0) {
+          scim_error(400, 'userName is immutable: mailcow cannot rename mailboxes', 'mutability');
+        }
+        break;
+      case 'displayname':
+        scim_state_set_full($state, trim((string) $value));
+        $state['name_dirty'] = true;
+        break;
+      case 'name':
+        if (!is_array($value)) {
+          scim_error(400, "'name' must be a complex object", 'invalidValue');
+        }
+        if (array_key_exists('formatted', $value)) {
+          scim_state_set_full($state, trim((string) $value['formatted']));
+          $state['name_dirty'] = true;
+        }
+        if (array_key_exists('givenname', $value)) {
+          $state['given'] = trim((string) $value['givenname']);
+          $state['name_dirty'] = true;
+        }
+        if (array_key_exists('familyname', $value)) {
+          $state['family'] = trim((string) $value['familyname']);
+          $state['name_dirty'] = true;
+        }
+        break;
+      case 'name.formatted':
+        scim_state_set_full($state, trim((string) $value));
+        $state['name_dirty'] = true;
+        break;
+      case 'name.givenname':
+        $state['given'] = trim((string) $value);
+        $state['name_dirty'] = true;
+        break;
+      case 'name.familyname':
+        $state['family'] = trim((string) $value);
+        $state['name_dirty'] = true;
+        break;
+      case 'active':
+        $state['active'] = (int) scim_to_bool($value);
+        $state['active_dirty'] = true;
+        break;
+      case 'externalid':
+        $state['external_id'] = $value === null ? null : (string) $value;
+        $state['external_dirty'] = true;
+        break;
+      case 'emails':
+        scim_patch_check_emails($value, null, $op_name, $row);
+        break;
+      default:
+        if ($key === strtolower(SCIM_URN_EXT)) {
+          if (!is_array($value)) {
+            scim_error(400, 'Extension value must be a complex object', 'invalidValue');
+          }
+          $attr = isset($value['template']) && is_string($value['template']) ? trim($value['template']) : null;
+          scim_template_immutable_check($attr, $op_name, $row, $token);
+          break;
+        }
+        if ($key === strtolower(SCIM_URN_USER)) {
+          if (!is_array($value)) {
+            scim_error(400, 'Schema value must be a complex object', 'invalidValue');
+          }
+          scim_patch_apply_object($value, $op_name, $state, $row, $token);
+          break;
+        }
+        if (in_array($key, scim_ignored_attrs(), true)) {
+          break; // unstored-but-standard core attribute — accepted and ignored
+        }
+        // Entra ID sends path-less operations with flattened path-like keys,
+        // e.g. {"emails[type eq \"work\"].value": "..."} — delegate to the
+        // path parser (which 400s on genuinely unknown attributes)
+        if (str_contains($key, '.') || str_contains($key, '[') || str_contains($key, ':')) {
+          $parsed = scim_parse_path($key);
+          if (!empty($parsed['ignored'])) {
+            break;
+          }
+          scim_patch_apply_path($parsed, $value, $op_name, $state, $row, $token);
+          break;
+        }
+        scim_error(400, "Unknown attribute '$key'", 'invalidPath');
+    }
+  }
+}
+
+/**
+ * Apply one PATCH operation with an explicit path.
+ */
+function scim_patch_apply_path(array $parsed, mixed $value, string $op_name, array &$state, array $row, array $token): void {
+  $spec   = $parsed['spec'];
+  $filter = $parsed['filter'];
+  $sub    = $parsed['sub'];
+
+  if ($spec['urn'] === 'ext') {
+    if ($spec['parts'] === ['template'] || ($spec['parts'] === [] && $sub === 'template')) {
+      $attr = is_string($value) ? trim($value) : null;
+      scim_template_immutable_check($attr, $op_name, $row, $token);
+      return;
+    }
+    if ($spec['parts'] === []) {
+      if ($op_name === 'remove') {
+        scim_template_immutable_check(null, 'remove', $row, $token);
+        return;
+      }
+      if (!is_array($value)) {
+        scim_error(400, 'Extension value must be a complex object', 'invalidValue');
+      }
+      $attr = isset($value['template']) && is_string($value['template']) ? trim($value['template']) : null;
+      scim_template_immutable_check($attr, $op_name, $row, $token);
+      return;
+    }
+    scim_error(400, 'Unsupported extension path', 'invalidPath');
+  }
+
+  $base = $spec['parts'][0];
+  $path_sub = $spec['parts'][1] ?? $sub;
+
+  switch ($base) {
+    case 'username':
+      if ($op_name === 'remove') {
+        scim_error(400, "userName is required and cannot be removed", 'mutability');
+      }
+      if (!is_string($value) || strcasecmp(trim($value), $row['username']) !== 0) {
+        scim_error(400, 'userName is immutable: mailcow cannot rename mailboxes', 'mutability');
+      }
+      break;
+
+    case 'displayname':
+      scim_state_set_full($state, $op_name === 'remove' ? '' : trim((string) $value));
+      $state['name_dirty'] = true;
+      break;
+
+    case 'name':
+      if ($path_sub === null) {
+        if ($op_name === 'remove') {
+          $state['given'] = '';
+          $state['family'] = '';
+          $state['name_dirty'] = true;
+          break;
+        }
+        if (!is_array($value)) {
+          scim_error(400, "'name' must be a complex object", 'invalidValue');
+        }
+        scim_patch_apply_object(['name' => $value], $op_name, $state, $row, $token);
+        break;
+      }
+      $val = $op_name === 'remove' ? '' : trim((string) $value);
+      if ($path_sub === 'formatted') {
+        scim_state_set_full($state, $val);
+      } elseif ($path_sub === 'givenname') {
+        $state['given'] = $val;
+      } elseif ($path_sub === 'familyname') {
+        $state['family'] = $val;
+      }
+      $state['name_dirty'] = true;
+      break;
+
+    case 'active':
+      if ($op_name === 'remove') {
+        scim_error(400, "'active' cannot be removed", 'invalidValue');
+      }
+      $state['active'] = (int) scim_to_bool($value);
+      $state['active_dirty'] = true;
+      break;
+
+    case 'externalid':
+      if ($op_name === 'remove') {
+        $state['external_id'] = null;
+      } else {
+        $state['external_id'] = $value === null ? null : (string) $value;
+      }
+      $state['external_dirty'] = true;
+      break;
+
+    case 'emails':
+      // $filter (if present) selects target items; since emails are derived
+      // from userName, only no-op modifications are accepted regardless
+      scim_patch_check_emails($value, $path_sub, $op_name, $row);
+      break;
+
+    case 'id':
+      scim_error(400, "'id' is read-only", 'mutability');
+
+    case 'meta':
+      // read-only, server-controlled — ignored
+      break;
+
+    case 'schemas':
+      break;
+
+    default:
+      scim_error(400, "Unsupported PATCH path", 'invalidPath');
+  }
+}
+
+function scim_patch_user(string $scim_id, array $body, array $token): never {
+  global $pdo;
+
+  $row = scim_fetch_row_by_scim_id($scim_id, $token);
+  if (!$row) {
+    scim_error(404, 'User not found');
+  }
+
+  scim_require_schema($body, SCIM_URN_PATCHOP);
+
+  $operations = $body['operations'] ?? null;
+  if (!is_array($operations) || !array_is_list($operations) || count($operations) === 0) {
+    scim_error(400, "'Operations' must be a non-empty array", 'invalidSyntax');
+  }
+
+  $name_parts = explode(' ', trim((string) ($row['name'] ?? '')), 2);
+  $state = [
+    'given'          => $name_parts[0] ?? '',
+    'family'         => $name_parts[1] ?? '',
+    'name_dirty'     => false,
+    'active'         => (int) $row['active'],
+    'active_dirty'   => false,
+    'external_id'    => $row['external_id'],
+    'external_dirty' => false,
+  ];
+
+  foreach ($operations as $op) {
+    if (!is_array($op)) {
+      scim_error(400, 'Each operation must be an object', 'invalidSyntax');
+    }
+    $op_name = strtolower((string) ($op['op'] ?? ''));
+    if (!in_array($op_name, ['add', 'replace', 'remove'], true)) {
+      scim_error(400, "Unsupported operation '{$op_name}'", 'invalidSyntax');
+    }
+    $path      = $op['path'] ?? null;
+    $has_value = array_key_exists('value', $op);
+    $value     = $op['value'] ?? null;
+
+    if ($op_name !== 'remove' && !$has_value) {
+      scim_error(400, "'value' is required for $op_name operations", 'invalidValue');
+    }
+
+    if ($path === null) {
+      if ($op_name === 'remove') {
+        scim_error(400, "'path' is required for remove operations", 'noTarget');
+      }
+      if (!is_array($value) || array_is_list($value)) {
+        scim_error(400, "'value' must be an object when 'path' is omitted", 'invalidValue');
+      }
+      scim_patch_apply_object($value, $op_name, $state, $row, $token);
+      continue;
+    }
+
+    if (!is_string($path) || trim($path) === '') {
+      scim_error(400, "'path' must be a non-empty string", 'invalidPath');
+    }
+    $parsed = scim_parse_path($path);
+    if (!empty($parsed['ignored'])) {
+      continue; // unstored-but-standard core attribute — accepted and ignored
+    }
+    scim_patch_apply_path($parsed, $value, $op_name, $state, $row, $token);
+  }
+
+  // Validate externalId uniqueness BEFORE any write — RFC 7644 §3.5.2 requires
+  // PATCH to be atomic; a 409 must not leave earlier operations applied
+  if ($state['external_dirty'] && $state['external_id'] !== null) {
+    $stmt = $pdo->prepare("SELECT `username` FROM `scim_maps` WHERE `external_id` = :eid AND `username` != :username");
+    $stmt->execute([':eid' => $state['external_id'], ':username' => $row['username']]);
+    if ($stmt->fetch(PDO::FETCH_ASSOC)) {
+      scim_error(409, "externalId '{$state['external_id']}' is already mapped to a different user", 'uniqueness');
+    }
+  }
+
+  $update = [];
+  if ($state['name_dirty']) {
+    $new_name = trim($state['given'] . ' ' . $state['family']);
+    if ($new_name === '') {
+      // mailbox() treats an empty name as "keep current" — fall back to the
+      // local part (mirrors creation defaults) so clears are not silent no-ops
+      $new_name = strstr($row['username'], '@', true) ?: $row['username'];
+    }
+    $update['name'] = $new_name;
+  }
+  if ($state['active_dirty']) {
+    $update['active'] = $state['active'];
+  }
+  if (!empty($update)) {
+    scim_setup_session();
+    scim_mailbox_call('edit', 'mailbox', array_merge(['username' => [$row['username']]], $update));
+  }
+
+  if ($state['external_dirty']) {
+    $stmt = $pdo->prepare("UPDATE `scim_maps` SET `external_id` = :eid WHERE `username` = :username");
+    $stmt->execute([':eid' => $state['external_id'], ':username' => $row['username']]);
+  }
+
+  scim_log('info', "Patched mailbox '{$row['username']}' via SCIM (token ID {$token['id']})");
+  $fresh = scim_fetch_row_by_scim_id($scim_id, $token);
+  scim_respond(scim_project_from_query(scim_user_to_response($fresh)));
+}
+
+function scim_delete_user(string $scim_id, array $token): never {
+  $row = scim_fetch_row_by_scim_id($scim_id, $token);
+  if (!$row) {
+    scim_error(404, 'User not found');
+  }
 
   scim_setup_session();
-  // Soft deactivate — preserve mail data
-  mailbox('edit', 'mailbox', [
-    'username' => [$id],
+  // Deliberate deviation from RFC 7644 §3.6: DELETE deactivates the mailbox
+  // instead of destroying it, to preserve mail data. The resource remains
+  // retrievable with active=false.
+  scim_mailbox_call('edit', 'mailbox', [
+    'username' => [$row['username']],
     'active'   => 0,
   ]);
 
   // scim_maps row intentionally kept for audit trail
 
-  scim_log('info', "Deactivated mailbox '$id' via SCIM DELETE (token ID {$token['id']})");
-  http_response_code(204);
-  exit;
+  scim_log('info', "Deactivated mailbox '{$row['username']}' via SCIM DELETE (token ID {$token['id']})");
+  scim_respond(null, 204);
 }

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -1158,7 +1158,6 @@ function init_db_schema()
           "domain_restriction" => "VARCHAR(255) DEFAULT NULL",
           "template"           => "VARCHAR(255) DEFAULT NULL",
           "allow_from"         => "TEXT NOT NULL",
-          "skip_ip_check"      => "TINYINT(1) NOT NULL DEFAULT '0'",
           "active"             => "TINYINT(1) NOT NULL DEFAULT '1'",
           "created"            => "DATETIME(0) NOT NULL DEFAULT NOW(0)",
           "modified"           => "DATETIME ON UPDATE CURRENT_TIMESTAMP"

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -4,7 +4,7 @@ function init_db_schema()
   try {
     global $pdo;
 
-    $db_version = "19022026_1220";
+    $db_version = "16032026_1000";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));
@@ -375,7 +375,7 @@ function init_db_schema()
           "custom_attributes" => "JSON NOT NULL DEFAULT ('{}')",
           "kind" => "VARCHAR(100) NOT NULL DEFAULT ''",
           "multiple_bookings" => "INT NOT NULL DEFAULT -1",
-          "authsource" => "ENUM('mailcow', 'keycloak', 'generic-oidc', 'ldap') DEFAULT 'mailcow'",
+          "authsource" => "ENUM('mailcow', 'keycloak', 'generic-oidc', 'ldap', 'scim') DEFAULT 'mailcow'",
           "created" => "DATETIME(0) NOT NULL DEFAULT NOW(0)",
           "modified" => "DATETIME ON UPDATE CURRENT_TIMESTAMP",
           "active" => "TINYINT(1) NOT NULL DEFAULT '1'"
@@ -1146,6 +1146,62 @@ function init_db_schema()
         "keys" => array(
           "primary" => array(
             "" => array("refresh_token")
+          )
+        ),
+        "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"
+      ),
+      "scim_tokens" => array(
+        "cols" => array(
+          "id"                 => "INT NOT NULL AUTO_INCREMENT",
+          "description"        => "VARCHAR(255) NOT NULL DEFAULT ''",
+          "token_hash"         => "VARCHAR(255) NOT NULL",
+          "domain_restriction" => "VARCHAR(255) DEFAULT NULL",
+          "template"           => "VARCHAR(255) DEFAULT NULL",
+          "allow_from"         => "TEXT NOT NULL",
+          "skip_ip_check"      => "TINYINT(1) NOT NULL DEFAULT '0'",
+          "active"             => "TINYINT(1) NOT NULL DEFAULT '1'",
+          "created"            => "DATETIME(0) NOT NULL DEFAULT NOW(0)",
+          "modified"           => "DATETIME ON UPDATE CURRENT_TIMESTAMP"
+        ),
+        "keys" => array(
+          "primary" => array(
+            "" => array("id")
+          ),
+          "unique" => array(
+            "token_hash" => array("token_hash")
+          )
+        ),
+        "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"
+      ),
+      "scim_maps" => array(
+        "cols" => array(
+          "id"          => "INT NOT NULL AUTO_INCREMENT",
+          "external_id" => "VARCHAR(255) NOT NULL",
+          "username"    => "VARCHAR(255) NOT NULL",
+          "token_id"    => "INT NOT NULL",
+          "created"     => "DATETIME(0) NOT NULL DEFAULT NOW(0)"
+        ),
+        "keys" => array(
+          "primary" => array(
+            "" => array("id")
+          ),
+          "unique" => array(
+            "scim_maps_username"          => array("username"),
+            "scim_maps_external_id_token" => array("external_id", "token_id")
+          ),
+          "fkey" => array(
+            "fk_scim_maps_username" => array(
+              "col"    => "username",
+              "ref"    => "mailbox.username",
+              "delete" => "CASCADE",
+              "update" => "NO ACTION"
+            ),
+            "fk_scim_maps_token_id" => array(
+              "col"    => "token_id",
+              "ref"    => "scim_tokens.id",
+              "delete" => "CASCADE",
+              "update" => "NO ACTION"
+            )
           )
         ),
         "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -1156,8 +1156,10 @@ function init_db_schema()
           "description"        => "VARCHAR(255) NOT NULL DEFAULT ''",
           "token_hash"         => "VARCHAR(255) NOT NULL",
           "domain_restriction" => "VARCHAR(255) DEFAULT NULL",
-          "template"           => "VARCHAR(255) DEFAULT NULL",
           "allow_from"         => "TEXT NOT NULL",
+          "default_template"   => "VARCHAR(255) DEFAULT NULL",
+          "mappers"            => "TEXT DEFAULT NULL",
+          "templates"          => "TEXT DEFAULT NULL",
           "active"             => "TINYINT(1) NOT NULL DEFAULT '1'",
           "created"            => "DATETIME(0) NOT NULL DEFAULT NOW(0)",
           "modified"           => "DATETIME ON UPDATE CURRENT_TIMESTAMP"

--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -4,7 +4,7 @@ function init_db_schema()
   try {
     global $pdo;
 
-    $db_version = "16032026_1000";
+    $db_version = "01082026_1000";
 
     $stmt = $pdo->query("SHOW TABLES LIKE 'versions'");
     $num_results = count($stmt->fetchAll(PDO::FETCH_ASSOC));
@@ -1160,6 +1160,7 @@ function init_db_schema()
           "default_template"   => "VARCHAR(255) DEFAULT NULL",
           "mappers"            => "TEXT DEFAULT NULL",
           "templates"          => "TEXT DEFAULT NULL",
+          "allow_claim"        => "TINYINT(1) NOT NULL DEFAULT '0'",
           "active"             => "TINYINT(1) NOT NULL DEFAULT '1'",
           "created"            => "DATETIME(0) NOT NULL DEFAULT NOW(0)",
           "modified"           => "DATETIME ON UPDATE CURRENT_TIMESTAMP"
@@ -1174,21 +1175,31 @@ function init_db_schema()
         ),
         "attr" => "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC"
       ),
+      // One row per SCIM-managed mailbox: scim_id is the stable, opaque SCIM
+      // resource id (RFC 7643 §3.1); external_id is the IdP's identifier;
+      // token_id records provenance (survives token deletion via SET NULL);
+      // template stores the mailbox template resolved at creation time.
       "scim_maps" => array(
         "cols" => array(
           "id"          => "INT NOT NULL AUTO_INCREMENT",
-          "external_id" => "VARCHAR(255) NOT NULL",
+          "scim_id"     => "VARCHAR(36) DEFAULT NULL",
+          "external_id" => "VARCHAR(255) DEFAULT NULL",
           "username"    => "VARCHAR(255) NOT NULL",
-          "token_id"    => "INT NOT NULL",
-          "created"     => "DATETIME(0) NOT NULL DEFAULT NOW(0)"
+          "token_id"    => "INT DEFAULT NULL",
+          "template"    => "VARCHAR(255) DEFAULT NULL",
+          "created"     => "DATETIME(0) NOT NULL DEFAULT NOW(0)",
+          "modified"    => "DATETIME ON UPDATE CURRENT_TIMESTAMP"
         ),
         "keys" => array(
           "primary" => array(
             "" => array("id")
           ),
           "unique" => array(
-            "scim_maps_username"          => array("username"),
-            "scim_maps_external_id_token" => array("external_id", "token_id")
+            "scim_maps_scim_id"  => array("scim_id"),
+            "scim_maps_username" => array("username")
+          ),
+          "key" => array(
+            "scim_maps_external_id" => array("external_id")
           ),
           "fkey" => array(
             "fk_scim_maps_username" => array(
@@ -1200,7 +1211,7 @@ function init_db_schema()
             "fk_scim_maps_token_id" => array(
               "col"    => "token_id",
               "ref"    => "scim_tokens.id",
-              "delete" => "CASCADE",
+              "delete" => "SET NULL",
               "update" => "NO ACTION"
             )
           )

--- a/data/web/inc/prerequisites.inc.php
+++ b/data/web/inc/prerequisites.inc.php
@@ -294,6 +294,7 @@ require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.quarantine.inc.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.quota_notification.inc.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.ratelimit.inc.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.rspamd.inc.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.scim.inc.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.tls_policy_maps.inc.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.transports.inc.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/init_db.inc.php';

--- a/data/web/inc/triggers.admin.inc.php
+++ b/data/web/inc/triggers.admin.inc.php
@@ -121,5 +121,20 @@ if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == "admi
 	if (isset($_POST["mass_send"])) {
 		sys_mail($_POST);
 	}
+  if (isset($_POST["add_scim_token"])) {
+    require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.scim.inc.php';
+    $raw_token = scim_token('add', $_POST);
+    if ($raw_token !== false) {
+      $_SESSION['scim_new_token'] = $raw_token;
+    }
+  }
+  if (isset($_POST["edit_scim_token"])) {
+    require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.scim.inc.php';
+    scim_token('edit', $_POST);
+  }
+  if (isset($_POST["delete_scim_token"])) {
+    require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.scim.inc.php';
+    scim_token('delete', ['id' => intval($_POST['id'] ?? 0)]);
+  }
 }
 ?>

--- a/data/web/js/site/admin.js
+++ b/data/web/js/site/admin.js
@@ -871,4 +871,103 @@ jQuery(function($){
     if ($(elem).parent().parent().parent().parent().children().length > 2)
       $(elem).parent().parent().parent().remove();
   }
+
+  // ── SCIM attribute mapping helper ──────────────────────────────────────────
+  // Builds a mapper row, appends it to listSelector, then applies selectpicker.
+  // Options are sourced from the Default template select already in the list,
+  // which is server-rendered by Twig — no inline <script> data needed.
+  function addScimMapperRow(listSelector, delBtnClass, mapperVal, templateVal) {
+    var $list = $(listSelector);
+    var $row  = $('<div class="row px-2 mb-1"></div>');
+    var $col1 = $('<div class="col-5 p-0 pe-2"></div>');
+    $col1.append($('<input type="text" class="form-control" name="mappers">').val(mapperVal || ''));
+    var $col2 = $('<div class="col-5 p-0 pe-2"></div>');
+    var $sel  = $('<select class="form-control" name="templates"><option value="">-- template --</option></select>');
+    // Selectpicker hides but does not remove the native <select> from the DOM,
+    // so we can still read its <option> elements to build our new select.
+    $list.find('select[name="default_template"]').find('option[value!=""]').each(function() {
+      $sel.append($('<option></option>').val($(this).val()).text($.trim($(this).text())));
+    });
+    $col2.append($sel);
+    var $col3 = $('<div class="col-2 p-0 d-flex"></div>');
+    $col3.append($('<button type="button" class="btn btn-sm btn-secondary ms-auto ' + delBtnClass + '"><i class="bi bi-x-lg"></i></button>'));
+    $row.append($col1).append($col2).append($col3);
+    $list.append($row);
+    // Apply selectpicker (matching the global init in mailcow.js) after DOM append
+    $sel.selectpicker({'styleBase': 'btn btn-xs-lg', 'noneSelectedText': lang_footer.nothing_selected, 'liveSearch': true});
+    $sel.selectpicker('val', templateVal || '');
+  }
+
+  // Seed the add form with one empty mapper row on page load
+  addScimMapperRow('#scim_add_mapping_list', 'scim_rolemap_del_new', '', '');
+
+  // ── SCIM attribute mapping — edit modal ────────────────────────────────────
+  $('.scim_rolemap_add').click(function(e) {
+    e.preventDefault();
+    addScimMapperRow('#scim_mapping_list', 'scim_rolemap_del', '', '');
+  });
+  $(document).on('click', '#scim_mapping_list .scim_rolemap_del', function(e) {
+    e.preventDefault();
+    $(this).closest('.row').remove();
+  });
+
+  // ── SCIM attribute mapping — add form ──────────────────────────────────────
+  $('.scim_rolemap_add_new').click(function(e) {
+    e.preventDefault();
+    addScimMapperRow('#scim_add_mapping_list', 'scim_rolemap_del_new', '', '');
+  });
+  $(document).on('click', '#scim_add_mapping_list .scim_rolemap_del_new', function(e) {
+    e.preventDefault();
+    $(this).closest('.row').remove();
+  });
+
+  // ── SCIM delete token — Bootstrap confirmation modal ───────────────────────
+  $(document).on('click', '.scim-delete-btn', function(e) {
+    e.preventDefault();
+    var tokenId     = $(this).data('id');
+    var description = $(this).data('description');
+    $('#ItemsToDelete').empty().append($('<li>').text(description));
+    $('#ConfirmDeleteModal').modal('show')
+      .one('click', '#IsConfirmed', function() {
+        var $form = $('<form method="post"></form>');
+        $form.append($('<input type="hidden" name="delete_scim_token" value="1">'));
+        $form.append($('<input type="hidden" name="id">').val(tokenId));
+        $form.append($('<input type="hidden" name="csrf_token">').val(csrf_token));
+        $('body').append($form);
+        $form.submit();
+      })
+      .one('click', '#isCanceled', function() {
+        $('#ConfirmDeleteModal').off();
+        $('#ConfirmDeleteModal').modal('hide');
+      });
+  });
+
+  // ── SCIM edit modal — populate fields from data-* attributes ───────────────
+  $('#scimEditModal').on('show.bs.modal', function(event) {
+    var btn = $(event.relatedTarget);
+    $('#scimEditId').val(btn.data('id'));
+    $('#scimEditDescription').val(btn.data('description'));
+    $('#scimEditDomainRestriction').selectpicker('val', btn.data('domain-restriction') || '');
+    $('#scimEditAllowFrom').val(btn.data('allow-from') || '');
+    $('#scimEditActive').val(btn.data('active'));
+
+    // Set default template via selectpicker API to update the custom dropdown display
+    $('#scimEditTemplate').selectpicker('val', btn.data('default-template') || '');
+
+    // Remove all injected mapper rows, then rebuild from data-* attributes
+    $('#scim_mapping_list').find('.row:not(.scim-default-row)').remove();
+
+    var mappers   = btn.data('mappers')   || [];
+    var templates = btn.data('templates') || [];
+    if (!Array.isArray(mappers))   { try { mappers   = JSON.parse(mappers);   } catch(e) { mappers   = []; } }
+    if (!Array.isArray(templates)) { try { templates = JSON.parse(templates); } catch(e) { templates = []; } }
+
+    if (mappers.length === 0) {
+      addScimMapperRow('#scim_mapping_list', 'scim_rolemap_del', '', '');
+    } else {
+      for (var i = 0; i < mappers.length; i++) {
+        addScimMapperRow('#scim_mapping_list', 'scim_rolemap_del', mappers[i], templates[i] || '');
+      }
+    }
+  });
 });

--- a/data/web/js/site/admin.js
+++ b/data/web/js/site/admin.js
@@ -880,9 +880,9 @@ jQuery(function($){
     var $list = $(listSelector);
     var $row  = $('<div class="row px-2 mb-1"></div>');
     var $col1 = $('<div class="col-5 p-0 pe-2"></div>');
-    $col1.append($('<input type="text" class="form-control" name="mappers">').val(mapperVal || ''));
+    $col1.append($('<input type="text" class="form-control" name="mappers[]">').val(mapperVal || ''));
     var $col2 = $('<div class="col-5 p-0 pe-2"></div>');
-    var $sel  = $('<select class="form-control" name="templates"><option value="">-- template --</option></select>');
+    var $sel  = $('<select class="form-control" name="templates[]"><option value="">-- template --</option></select>');
     // Selectpicker hides but does not remove the native <select> from the DOM,
     // so we can still read its <option> elements to build our new select.
     $list.find('select[name="default_template"]').find('option[value!=""]').each(function() {
@@ -950,6 +950,7 @@ jQuery(function($){
     $('#scimEditDomainRestriction').selectpicker('val', btn.data('domain-restriction') || '');
     $('#scimEditAllowFrom').val(btn.data('allow-from') || '');
     $('#scimEditActive').val(btn.data('active'));
+    $('#scimEditAllowClaim').prop('checked', String(btn.data('allow-claim')) === '1');
 
     // Set default template via selectpicker API to update the custom dropdown display
     $('#scimEditTemplate').selectpicker('val', btn.data('default-template') || '');

--- a/data/web/lang/lang.en-gb.json
+++ b/data/web/lang/lang.en-gb.json
@@ -1214,7 +1214,10 @@
         "verified_fido2_login": "Verified FIDO2 login",
         "verified_totp_login": "Verified TOTP login",
         "verified_webauthn_login": "Verified WebAuthn login",
-        "verified_yotp_login": "Verified Yubico OTP login"
+        "verified_yotp_login": "Verified Yubico OTP login",
+        "scim_token_added": "SCIM token %s has been added",
+        "scim_token_updated": "Changes to SCIM token %s have been saved",
+        "scim_token_deleted": "SCIM token %s has been deleted"
     },
     "tfa": {
         "authenticators": "Authenticators",

--- a/data/web/lang/lang.en-gb.json
+++ b/data/web/lang/lang.en-gb.json
@@ -1216,7 +1216,10 @@
         "verified_fido2_login": "Verified FIDO2 login",
         "verified_totp_login": "Verified TOTP login",
         "verified_webauthn_login": "Verified WebAuthn login",
-        "verified_yotp_login": "Verified Yubico OTP login"
+        "verified_yotp_login": "Verified Yubico OTP login",
+        "scim_token_added": "SCIM token %s has been added",
+        "scim_token_updated": "Changes to SCIM token %s have been saved",
+        "scim_token_deleted": "SCIM token %s has been deleted"
     },
     "tfa": {
         "authenticators": "Authenticators",

--- a/data/web/scim.php
+++ b/data/web/scim.php
@@ -1,0 +1,187 @@
+<?php
+
+// Block browser-initiated requests
+if (isset($_SERVER['HTTP_SEC_FETCH_DEST']) && $_SERVER['HTTP_SEC_FETCH_DEST'] === 'document') {
+  http_response_code(403);
+  exit;
+}
+
+// Always respond with SCIM content type
+header('Content-Type: application/scim+json');
+
+// ─── Minimal bootstrap (mirrors keycloak-sync.php pattern) ──────────────────
+
+require_once __DIR__ . '/inc/vars.inc.php';
+if (file_exists(__DIR__ . '/inc/vars.local.inc.php')) {
+  include_once __DIR__ . '/inc/vars.local.inc.php';
+}
+require_once __DIR__ . '/inc/lib/vendor/autoload.php';
+
+// Init database
+$dsn = $database_type . ':unix_socket=' . $database_sock . ';dbname=' . $database_name;
+$opt = [
+  PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+  PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+  PDO::ATTR_EMULATE_PREPARES   => false,
+];
+try {
+  $pdo = new PDO($dsn, $database_user, $database_pass, $opt);
+} catch (PDOException $e) {
+  http_response_code(500);
+  echo json_encode([
+    'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+    'status'  => '500',
+    'detail'  => 'Database connection failed',
+  ]);
+  exit;
+}
+
+// Init Redis
+$redis = new Redis();
+try {
+  if (!empty(getenv('REDIS_SLAVEOF_IP'))) {
+    $redis->connect(getenv('REDIS_SLAVEOF_IP'), getenv('REDIS_SLAVEOF_PORT'));
+  } else {
+    $redis->connect('redis-mailcow', 6379);
+  }
+  $redis->auth(getenv('REDISPASS'));
+} catch (Exception $e) {
+  http_response_code(500);
+  echo json_encode([
+    'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+    'status'  => '500',
+    'detail'  => 'Cache connection failed',
+  ]);
+  exit;
+}
+
+// Start session so mailbox() can use $_SESSION
+session_name('MAILCOW_SCIM');
+session_start();
+
+// Load required functions
+require_once __DIR__ . '/inc/functions.inc.php';
+require_once __DIR__ . '/inc/functions.auth.inc.php';
+require_once __DIR__ . '/inc/functions.mailbox.inc.php';
+require_once __DIR__ . '/inc/functions.ratelimit.inc.php';
+require_once __DIR__ . '/inc/functions.acl.inc.php';
+require_once __DIR__ . '/inc/functions.scim.inc.php';
+
+// ─── Authentication ──────────────────────────────────────────────────────────
+
+$scim_token = scim_authenticate();
+
+// ─── Routing ─────────────────────────────────────────────────────────────────
+
+$method = $_SERVER['REQUEST_METHOD'];
+$path   = trim($_GET['path'] ?? '', '/');
+// Normalize empty path
+if ($path === '') {
+  http_response_code(404);
+  echo json_encode([
+    'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+    'status'  => '404',
+    'detail'  => 'Not found',
+    'scimType'=> 'notFound',
+  ]);
+  exit;
+}
+
+// Split path into segments
+$segments = explode('/', $path, 2);
+$resource = $segments[0];
+$resource_id = isset($segments[1]) ? rawurldecode($segments[1]) : null;
+
+// Log the request
+$redis->lPush('SCIM_LOG', json_encode([
+  'time'     => time(),
+  'priority' => 'info',
+  'task'     => 'SCIM',
+  'message'  => $method . ' /scim/v2/' . $path . ' from ' . ($_SERVER['REMOTE_ADDR'] ?? '?') . ' (token ID ' . $scim_token['id'] . ')',
+]));
+
+// Reset session return buffer
+$_SESSION['return'] = [];
+
+try {
+  // Handle OPTIONS (CORS preflight)
+  if ($method === 'OPTIONS') {
+    header('Allow: GET, POST, PUT, PATCH, DELETE, OPTIONS');
+    http_response_code(204);
+    exit;
+  }
+
+  // Read JSON body for mutating methods
+  $body = [];
+  if (in_array($method, ['POST', 'PUT', 'PATCH'])) {
+    $raw  = file_get_contents('php://input');
+    $body = json_decode($raw, true) ?? [];
+  }
+
+  // Dispatch
+  switch ($resource) {
+    case 'ServiceProviderConfig':
+      if ($method !== 'GET') { http_response_code(405); exit; }
+      echo json_encode(scim_service_provider_config());
+      break;
+
+    case 'Schemas':
+      if ($method !== 'GET') { http_response_code(405); exit; }
+      echo json_encode(scim_schemas());
+      break;
+
+    case 'ResourceTypes':
+      if ($method !== 'GET') { http_response_code(405); exit; }
+      echo json_encode(scim_resource_types());
+      break;
+
+    case 'Users':
+      if ($resource_id === null) {
+        // Collection endpoints
+        if ($method === 'GET') {
+          echo json_encode(scim_list_users($scim_token));
+        } elseif ($method === 'POST') {
+          echo json_encode(scim_create_user($body, $scim_token));
+        } else {
+          http_response_code(405);
+        }
+      } else {
+        // Individual resource endpoints
+        if ($method === 'GET') {
+          echo json_encode(scim_get_user($resource_id, $scim_token));
+        } elseif ($method === 'PUT') {
+          echo json_encode(scim_replace_user($resource_id, $body, $scim_token));
+        } elseif ($method === 'PATCH') {
+          echo json_encode(scim_patch_user($resource_id, $body, $scim_token));
+        } elseif ($method === 'DELETE') {
+          scim_delete_user($resource_id, $scim_token);
+        } else {
+          http_response_code(405);
+        }
+      }
+      break;
+
+    default:
+      http_response_code(404);
+      echo json_encode([
+        'schemas'  => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+        'status'   => '404',
+        'detail'   => "Resource type '$resource' not found",
+        'scimType' => 'notFound',
+      ]);
+      break;
+  }
+} catch (Throwable $e) {
+  http_response_code(500);
+  echo json_encode([
+    'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+    'status'  => '500',
+    'detail'  => 'Internal server error',
+  ]);
+  $redis->lPush('SCIM_LOG', json_encode([
+    'time'     => time(),
+    'priority' => 'err',
+    'task'     => 'SCIM',
+    'message'  => 'Uncaught exception: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine(),
+  ]));
+}

--- a/data/web/scim.php
+++ b/data/web/scim.php
@@ -1,5 +1,9 @@
 <?php
 
+// Buffer all output so an exception mid-response can never append an error
+// envelope to an already-emitted body
+ob_start();
+
 // Block browser-initiated requests
 if (isset($_SERVER['HTTP_SEC_FETCH_DEST']) && $_SERVER['HTTP_SEC_FETCH_DEST'] === 'document') {
   http_response_code(403);
@@ -9,7 +13,7 @@ if (isset($_SERVER['HTTP_SEC_FETCH_DEST']) && $_SERVER['HTTP_SEC_FETCH_DEST'] ==
 // Always respond with SCIM content type
 header('Content-Type: application/scim+json');
 
-// ─── Minimal bootstrap (mirrors keycloak-sync.php pattern) ──────────────────
+// ─── Minimal bootstrap ───────────────────────────────────────────────────────
 
 require_once __DIR__ . '/inc/vars.inc.php';
 if (file_exists(__DIR__ . '/inc/vars.local.inc.php')) {
@@ -55,9 +59,9 @@ try {
   exit;
 }
 
-// Start session so mailbox() can use $_SESSION
-session_name('MAILCOW_SCIM');
-session_start();
+// SCIM is stateless: no PHP session is started. $_SESSION is used as a plain
+// array because mailbox() reads/writes it ($_SESSION['return'], ACLs).
+$_SESSION = [];
 
 // Load required functions
 require_once __DIR__ . '/inc/functions.inc.php';
@@ -67,30 +71,45 @@ require_once __DIR__ . '/inc/functions.ratelimit.inc.php';
 require_once __DIR__ . '/inc/functions.acl.inc.php';
 require_once __DIR__ . '/inc/functions.scim.inc.php';
 
+// ─── Path resolution ─────────────────────────────────────────────────────────
+// Derive the path from REQUEST_URI rather than the nginx-rewritten query
+// string: try_files re-injects the decoded URI into $args, which corrupts
+// percent-encoded characters ('+' in mailbox local parts, '&', '#').
+
+$uri_path = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
+if (!is_string($uri_path)) {
+  $uri_path = '';
+}
+if (preg_match('~^/scim/v2(?:/(.*))?$~', $uri_path, $m)) {
+  $path = trim($m[1] ?? '', '/');
+} else {
+  // Fallback (direct /scim.php?path=... invocation)
+  $path = trim((string) ($_GET['path'] ?? ''), '/');
+}
+$segments = $path === '' ? [] : array_map('rawurldecode', explode('/', $path));
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+// Query parameters, case-insensitively keyed (path helper param removed)
+$SCIM_QUERY = array_change_key_case($_GET, CASE_LOWER);
+unset($SCIM_QUERY['path']);
+
+// Handle OPTIONS before authentication: CORS preflights carry no Authorization
+if ($method === 'OPTIONS') {
+  header('Allow: GET, POST, PUT, PATCH, DELETE, OPTIONS');
+  http_response_code(204);
+  exit;
+}
+
 // ─── Authentication ──────────────────────────────────────────────────────────
 
 $scim_token = scim_authenticate();
 
 // ─── Routing ─────────────────────────────────────────────────────────────────
 
-$method = $_SERVER['REQUEST_METHOD'];
-$path   = trim($_GET['path'] ?? '', '/');
-// Normalize empty path
-if ($path === '') {
-  http_response_code(404);
-  echo json_encode([
-    'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
-    'status'  => '404',
-    'detail'  => 'Not found',
-    'scimType'=> 'notFound',
-  ]);
-  exit;
-}
-
-// Split path into segments
-$segments = explode('/', $path, 2);
-$resource = $segments[0];
-$resource_id = isset($segments[1]) ? rawurldecode($segments[1]) : null;
+$resource    = $segments[0] ?? '';
+$resource_id = $segments[1] ?? null;
+$extra_depth = count($segments) > 2;
 
 // Log the request
 $redis->lPush('SCIM_LOG', json_encode([
@@ -103,75 +122,155 @@ $redis->lPush('SCIM_LOG', json_encode([
 // Reset session return buffer
 $_SESSION['return'] = [];
 
+/**
+ * 405 with a proper error envelope and Allow header (RFC 7231 §6.5.5).
+ */
+function scim_method_not_allowed(string $allow): never {
+  scim_error(405, 'Method not allowed', '', ['Allow: ' . $allow . ', OPTIONS']);
+}
+
+/**
+ * RFC 7644 §4: filtering SHOULD be rejected with 403 on configuration endpoints.
+ */
+function scim_reject_config_filter(): void {
+  global $SCIM_QUERY;
+  if (isset($SCIM_QUERY['filter']) && $SCIM_QUERY['filter'] !== '') {
+    scim_error(403, 'Filtering is not supported on configuration endpoints', 'invalidFilter');
+  }
+}
+
 try {
-  // Handle OPTIONS (CORS preflight)
-  if ($method === 'OPTIONS') {
-    header('Allow: GET, POST, PUT, PATCH, DELETE, OPTIONS');
-    http_response_code(204);
-    exit;
+  if ($resource === '' || $extra_depth) {
+    scim_error(404, 'Not found');
   }
 
-  // Read JSON body for mutating methods
-  $body = [];
-  if (in_array($method, ['POST', 'PUT', 'PATCH'])) {
-    $raw  = file_get_contents('php://input');
-    $body = json_decode($raw, true) ?? [];
-  }
-
-  // Dispatch
   switch ($resource) {
     case 'ServiceProviderConfig':
-      if ($method !== 'GET') { http_response_code(405); exit; }
-      echo json_encode(scim_service_provider_config());
+      if ($resource_id !== null) {
+        scim_error(404, 'Not found');
+      }
+      scim_reject_config_filter();
+      if ($method !== 'GET') {
+        scim_method_not_allowed('GET');
+      }
+      scim_respond(scim_service_provider_config());
       break;
 
     case 'Schemas':
-      if ($method !== 'GET') { http_response_code(405); exit; }
-      echo json_encode(scim_schemas());
+      scim_reject_config_filter();
+      if ($method !== 'GET') {
+        scim_method_not_allowed('GET');
+      }
+      if ($resource_id === null) {
+        scim_respond(scim_schemas());
+      }
+      $schema = scim_schema_by_id($resource_id);
+      if ($schema === null) {
+        scim_error(404, "Schema '$resource_id' not found");
+      }
+      scim_respond($schema);
       break;
 
     case 'ResourceTypes':
-      if ($method !== 'GET') { http_response_code(405); exit; }
-      echo json_encode(scim_resource_types());
+      scim_reject_config_filter();
+      if ($method !== 'GET') {
+        scim_method_not_allowed('GET');
+      }
+      if ($resource_id === null) {
+        scim_respond(scim_resource_types());
+      }
+      $type = scim_resource_type_by_id($resource_id);
+      if ($type === null) {
+        scim_error(404, "ResourceType '$resource_id' not found");
+      }
+      scim_respond($type);
       break;
 
     case 'Users':
+      if ($resource_id === '.search') {
+        if ($method !== 'POST') {
+          scim_method_not_allowed('POST');
+        }
+        scim_search(scim_read_body(), $scim_token);
+      }
       if ($resource_id === null) {
         // Collection endpoints
         if ($method === 'GET') {
-          echo json_encode(scim_list_users($scim_token));
+          scim_query_users($scim_token, $SCIM_QUERY);
         } elseif ($method === 'POST') {
-          echo json_encode(scim_create_user($body, $scim_token));
+          scim_create_user(scim_read_body(), $scim_token);
         } else {
-          http_response_code(405);
+          scim_method_not_allowed('GET, POST');
         }
+      }
+      // Individual resource endpoints
+      if ($method === 'GET') {
+        scim_get_user($resource_id, $scim_token);
+      } elseif ($method === 'PUT') {
+        scim_replace_user($resource_id, scim_read_body(), $scim_token);
+      } elseif ($method === 'PATCH') {
+        scim_patch_user($resource_id, scim_read_body(), $scim_token);
+      } elseif ($method === 'DELETE') {
+        scim_delete_user($resource_id, $scim_token);
       } else {
-        // Individual resource endpoints
-        if ($method === 'GET') {
-          echo json_encode(scim_get_user($resource_id, $scim_token));
-        } elseif ($method === 'PUT') {
-          echo json_encode(scim_replace_user($resource_id, $body, $scim_token));
-        } elseif ($method === 'PATCH') {
-          echo json_encode(scim_patch_user($resource_id, $body, $scim_token));
-        } elseif ($method === 'DELETE') {
-          scim_delete_user($resource_id, $scim_token);
-        } else {
-          http_response_code(405);
-        }
+        scim_method_not_allowed('GET, PUT, PATCH, DELETE');
       }
       break;
 
-    default:
-      http_response_code(404);
-      echo json_encode([
-        'schemas'  => ['urn:ietf:params:scim:api:messages:2.0:Error'],
-        'status'   => '404',
-        'detail'   => "Resource type '$resource' not found",
-        'scimType' => 'notFound',
+    case '.search':
+      if ($resource_id !== null) {
+        scim_error(404, 'Not found');
+      }
+      if ($method !== 'POST') {
+        scim_method_not_allowed('POST');
+      }
+      scim_search(scim_read_body(), $scim_token);
+      break;
+
+    case 'Me':
+      // RFC 7644 §3.11: /Me is OPTIONAL; 501 signals "not implemented"
+      scim_error(501, 'The /Me endpoint is not implemented', '');
+      break;
+
+    case 'Groups':
+      // Groups are not implemented: mailcow has no native group-of-users
+      // object, and /ResourceTypes advertises User only — that remains the
+      // authoritative capability statement.
+      //
+      // Reads are nonetheless answered with an empty collection rather than a
+      // 404, because IdPs run a group discovery pass unconditionally without
+      // consulting /ResourceTypes (Authentik, Entra ID) and a hard error there
+      // fails the whole sync, users included. An empty ListResponse is a
+      // normal query result per RFC 7644 §3.4.2 and is truthful: no group
+      // resources exist here. Writes stay 501, so the pair reads as "there are
+      // no groups and none can be created".
+      //
+      // The filter is deliberately not parsed: an empty collection matches
+      // nothing whatever the filter says, and Group attributes (displayName,
+      // members) are absent from our attribute registry, so parsing one would
+      // wrongly yield 400 invalidFilter.
+      if ($method !== 'GET') {
+        scim_error(501, 'Group provisioning is not implemented; this provider manages Users only (see /scim/v2/ResourceTypes)', '');
+      }
+      if ($resource_id !== null) {
+        scim_error(404, 'Group not found');
+      }
+      scim_respond([
+        'schemas'      => [SCIM_URN_LIST],
+        'totalResults' => 0,
+        'startIndex'   => isset($SCIM_QUERY['startindex']) ? max(1, intval($SCIM_QUERY['startindex'])) : 1,
+        'itemsPerPage' => 0,
+        'Resources'    => [],
       ]);
       break;
+
+    default:
+      scim_error(404, "Resource type '$resource' not found");
   }
 } catch (Throwable $e) {
+  if (ob_get_length()) {
+    ob_clean();
+  }
   http_response_code(500);
   echo json_encode([
     'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],

--- a/data/web/templates/admin.twig
+++ b/data/web/templates/admin.twig
@@ -8,6 +8,7 @@
       <ul class="dropdown-menu">
         <li><button class="dropdown-item active" data-bs-target="#tab-config-admins" aria-selected="false" aria-controls="tab-config-admins" role="tab" data-bs-toggle="tab">{{ lang.admin.admins }}</button></li>
         <li><button class="dropdown-item" data-bs-target="#tab-config-identity-provider" aria-selected="false" aria-controls="tab-config-identity-provider" role="tab" data-bs-toggle="tab">Identity Provider</button></li>
+        <li><button class="dropdown-item" data-bs-target="#tab-config-scim" aria-selected="false" aria-controls="tab-config-scim" role="tab" data-bs-toggle="tab">SCIM</button></li>
         <!-- <li><button class="dropdown-item" data-bs-target="#tab-config-ldap-admins" aria-controls="tab-config-ldap-admins" role="tab" data-bs-toggle="tab">{{ lang.admin.admins_ldap }}</button></li> -->
         <li><button class="dropdown-item" data-bs-target="#tab-config-oauth2" aria-selected="false" aria-controls="tab-config-oauth2" role="tab" data-bs-toggle="tab">{{ lang.admin.oauth2_apps }}</button></li>
         <li><button class="dropdown-item" data-bs-target="#tab-config-rspamd" aria-selected="false" aria-controls="tab-config-rspamd" role="tab" data-bs-toggle="tab">Rspamd UI</button></li>
@@ -42,6 +43,7 @@
       <div class="tab-content" style="padding-top:20px">
         {% include 'admin/tab-config-admins.twig' %}
         {% include 'admin/tab-config-identity-provider.twig' %}
+        {% include 'admin/tab-config-scim.twig' %}
         {# {% include 'admin/tab-ldap.twig' %} #}
         {% include 'admin/tab-config-oauth2.twig' %}
         {% include 'admin/tab-config-rspamd.twig' %}

--- a/data/web/templates/admin/tab-config-scim.twig
+++ b/data/web/templates/admin/tab-config-scim.twig
@@ -53,6 +53,95 @@
       </script>
       {% endif %}
 
+      {# ── Edit token modal ────────────────────────────────────────────────── #}
+      <div class="modal fade" id="scimEditModal" tabindex="-1" role="dialog" aria-labelledby="scimEditModalLabel">
+        <div class="modal-dialog modal-lg" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="scimEditModalLabel">Edit SCIM Token</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <form method="post" autocomplete="off" id="scimEditForm">
+                <input type="hidden" name="edit_scim_token" value="1">
+                <input type="hidden" name="id" id="scimEditId">
+                <input type="hidden" name="active" id="scimEditActive">
+
+                <div class="row mb-2">
+                  <div class="col-md-3 d-flex align-items-center justify-content-md-end">
+                    <label class="control-label">Description</label>
+                  </div>
+                  <div class="col-12 col-md-9">
+                    <input type="text" class="form-control" name="description" id="scimEditDescription" required>
+                  </div>
+                </div>
+
+                <div class="row mb-2">
+                  <div class="col-md-3 d-flex align-items-center justify-content-md-end">
+                    <label class="control-label">Domain restriction <small class="text-muted">(optional)</small></label>
+                  </div>
+                  <div class="col-12 col-md-9">
+                    <select class="form-control" name="domain_restriction" id="scimEditDomainRestriction" data-live-search="true">
+                      <option value="">All domains</option>
+                      {% for domain in all_domains %}
+                      <option value="{{ domain }}">{{ domain }}</option>
+                      {% endfor %}
+                    </select>
+                  </div>
+                </div>
+
+                <div class="row mb-2">
+                  <div class="col-md-3 d-flex align-items-center justify-content-md-end">
+                    <label class="control-label">IP allow list <small class="text-muted">(optional)</small></label>
+                  </div>
+                  <div class="col-12 col-md-9">
+                    <input type="text" class="form-control" name="allow_from" id="scimEditAllowFrom" placeholder="192.168.1.0/24, 10.0.0.1">
+                  </div>
+                </div>
+
+                <div class="row mb-2">
+                  <div class="col-md-3 d-flex align-items-center justify-content-md-end">
+                    <label class="control-label">Attribute mapping</label>
+                  </div>
+                  <div class="col-12 col-md-9 col-lg-6">
+                    <div class="row px-2 align-items-center mb-1">
+                      <span class="col-5 p-0 pe-2"><small class="text-muted">mailcow_template value</small></span>
+                      <span class="col-5 p-0 pe-2"><small class="text-muted">Mailbox template</small></span>
+                      <div class="col-2 p-0 d-flex">
+                        <button type="button" class="btn btn-sm btn-secondary ms-auto scim_rolemap_add"><i class="bi bi-plus-lg"></i></button>
+                      </div>
+                    </div>
+                    <div id="scim_mapping_list">
+                      {# Default row — always present, required, no delete button #}
+                      <div class="row px-2 mb-1 scim-default-row">
+                        <div class="col-5 p-0 pe-2 d-flex align-items-center">
+                          <span>Default</span>
+                        </div>
+                        <div class="col-5 p-0 pe-2">
+                          <select class="form-control" name="default_template" id="scimEditTemplate" data-live-search="true" required>
+                            <option value="">Default</option>
+                            {% for tmpl in mbox_templates %}
+                            <option value="{{ tmpl.template }}">{{ tmpl.template }}</option>
+                            {% endfor %}
+                          </select>
+                        </div>
+                        <div class="col-2 p-0 d-flex"></div>
+                      </div>
+                      {# Attribute→template rows injected by JS when the modal opens #}
+                    </div>
+                  </div>
+                </div>
+
+              </form>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+              <button type="submit" form="scimEditForm" class="btn btn-primary">Save</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
       {# Existing tokens table #}
       {% if scim_tokens %}
       <div class="table-responsive mb-4">
@@ -61,7 +150,7 @@
             <tr>
               <th>Description</th>
               <th>Domain restriction</th>
-              <th>Template</th>
+              <th>Default template</th>
               <th>IP allow list</th>
               <th>Active</th>
               <th>Created</th>
@@ -73,7 +162,7 @@
             <tr>
               <td>{{ token.description }}</td>
               <td>{{ token.domain_restriction ?? '(all domains)' }}</td>
-              <td>{{ token.template ?? '(default)' }}</td>
+              <td>{{ token.default_template ?? '(default)' }}</td>
               <td><code>{{ token.allow_from ?: '(any)' }}</code></td>
               <td>
                 <form method="post" class="d-inline">
@@ -81,8 +170,10 @@
                   <input type="hidden" name="id" value="{{ token.id }}">
                   <input type="hidden" name="description" value="{{ token.description }}">
                   <input type="hidden" name="domain_restriction" value="{{ token.domain_restriction }}">
-                  <input type="hidden" name="template" value="{{ token.template }}">
+                  <input type="hidden" name="default_template" value="{{ token.default_template }}">
                   <input type="hidden" name="allow_from" value="{{ token.allow_from }}">
+                  <input type="hidden" name="mappers" value="{{ token.mappers }}">
+                  <input type="hidden" name="templates" value="{{ token.templates }}">
                   <input type="hidden" name="active" value="{{ token.active ? 0 : 1 }}">
                   <button type="submit" class="btn btn-xs btn-{{ token.active ? 'success' : 'secondary' }}">
                     {{ token.active ? 'Active' : 'Inactive' }}
@@ -90,12 +181,20 @@
                 </form>
               </td>
               <td>{{ token.created }}</td>
-              <td>
-                <form method="post" class="d-inline" onsubmit="return confirm('Delete this SCIM token?')">
-                  <input type="hidden" name="delete_scim_token" value="1">
-                  <input type="hidden" name="id" value="{{ token.id }}">
-                  <button type="submit" class="btn btn-xs btn-danger"><i class="bi bi-trash"></i></button>
-                </form>
+              <td class="text-nowrap">
+                <button type="button" class="btn btn-xs btn-primary scim-edit-btn"
+                  data-bs-toggle="modal" data-bs-target="#scimEditModal"
+                  data-id="{{ token.id }}"
+                  data-description="{{ token.description }}"
+                  data-domain-restriction="{{ token.domain_restriction }}"
+                  data-default-template="{{ token.default_template }}"
+                  data-allow-from="{{ token.allow_from }}"
+                  data-mappers="{{ token.mappers }}"
+                  data-templates="{{ token.templates }}"
+                  data-active="{{ token.active }}">
+                  <i class="bi bi-pencil"></i>
+                </button>
+                <button type="button" class="btn btn-xs btn-danger scim-delete-btn" data-id="{{ token.id }}" data-description="{{ token.description }}"><i class="bi bi-trash"></i></button>
               </td>
             </tr>
             {% endfor %}
@@ -127,21 +226,45 @@
                 <label class="control-label">Domain restriction <small class="text-muted">(optional)</small></label>
               </div>
               <div class="col-12 col-md-9 col-lg-4">
-                <input type="text" class="form-control" name="domain_restriction" placeholder="example.com (leave blank for all domains)">
+                <select class="form-control" name="domain_restriction" data-live-search="true">
+                  <option value="">All domains</option>
+                  {% for domain in all_domains %}
+                  <option value="{{ domain }}">{{ domain }}</option>
+                  {% endfor %}
+                </select>
               </div>
             </div>
 
             <div class="row mb-2">
               <div class="col-md-3 d-flex align-items-center justify-content-md-end">
-                <label class="control-label">Mailbox template <small class="text-muted">(optional)</small></label>
+                <label class="control-label">Attribute mapping</label>
               </div>
               <div class="col-12 col-md-9 col-lg-4">
-                <select class="form-control" name="template">
-                  <option value="">(Use system defaults)</option>
-                  {% for tmpl in mbox_templates %}
-                  <option value="{{ tmpl.template }}">{{ tmpl.template }}</option>
-                  {% endfor %}
-                </select>
+                <div class="row px-2 align-items-center mb-1">
+                  <span class="col-5 p-0 pe-2"><small class="text-muted">mailcow_template value</small></span>
+                  <span class="col-5 p-0 pe-2"><small class="text-muted">Mailbox template</small></span>
+                  <div class="col-2 p-0 d-flex">
+                    <button type="button" class="btn btn-sm btn-secondary ms-auto scim_rolemap_add_new"><i class="bi bi-plus-lg"></i></button>
+                  </div>
+                </div>
+                <div id="scim_add_mapping_list">
+                  {# Default row — always present, required, no delete button #}
+                  <div class="row px-2 mb-1 scim-default-row">
+                    <div class="col-5 p-0 pe-2 d-flex align-items-center">
+                      <span>Default</span>
+                    </div>
+                    <div class="col-5 p-0 pe-2">
+                      <select class="form-control" name="default_template" data-live-search="true" required>
+                        <option value="">Default</option>
+                        {% for tmpl in mbox_templates %}
+                        <option value="{{ tmpl.template }}">{{ tmpl.template }}</option>
+                        {% endfor %}
+                      </select>
+                    </div>
+                    <div class="col-2 p-0 d-flex"></div>
+                  </div>
+                  {# Optional attribute→template rows injected by JS #}
+                </div>
               </div>
             </div>
 

--- a/data/web/templates/admin/tab-config-scim.twig
+++ b/data/web/templates/admin/tab-config-scim.twig
@@ -1,0 +1,179 @@
+<div role="tabpanel" class="tab-pane fade" id="tab-config-scim" role="tabpanel" aria-labelledby="tab-config-scim">
+  <div class="card mb-4">
+    <div class="card-header d-flex fs-5">
+      <button class="btn d-md-none flex-grow-1 text-start" data-bs-target="#collapse-tab-config-scim" data-bs-toggle="collapse" aria-controls="collapse-tab-config-scim">
+        SCIM
+      </button>
+      <span class="d-none d-md-block">SCIM</span>
+    </div>
+    <div id="collapse-tab-config-scim" class="card-body collapse" data-bs-parent="#admin-content">
+
+      <p class="offset-sm-3 mb-4">
+        SCIM 2.0 (RFC 7644) allows Identity Providers (Keycloak, Entra ID, Okta, etc.) to push user
+        provisioning events to mailcow in real time. Generate a Bearer token below and configure your
+        IdP to use <code>{{ scim_base_url }}</code>
+        as the SCIM base URL.
+      </p>
+
+      {% if iam_settings.authsource != 'keycloak' and iam_settings.authsource != 'generic-oidc' and iam_settings.authsource != 'ldap' %}
+      <div class="alert alert-warning offset-sm-3 col-sm-9 mb-4">
+        <strong>No external identity provider configured.</strong>
+        SCIM-provisioned users will not be able to log in until a Keycloak, Generic-OIDC, or LDAP provider
+        is configured under <em>System &rsaquo; Configuration &rsaquo; Access &rsaquo; Identity Provider</em>.
+      </div>
+      {% endif %}
+
+      {# One-time raw token flash modal #}
+      {% if scim_new_token %}
+      <div class="modal fade" id="scimNewTokenModal" tabindex="-1" role="dialog">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">SCIM Token Created</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <p class="text-danger"><strong>Copy this token now — it will not be shown again.</strong></p>
+              <div class="input-group">
+                <input type="text" class="form-control font-monospace" id="scim_raw_token_display" readonly value="{{ scim_new_token }}">
+                <button class="btn btn-outline-secondary" type="button" onclick="navigator.clipboard.writeText(document.getElementById('scim_raw_token_display').value)">Copy</button>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-primary" data-bs-dismiss="modal">I have copied the token</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <script>
+        document.addEventListener('DOMContentLoaded', function () {
+          var el = document.getElementById('scimNewTokenModal');
+          if (el) { new bootstrap.Modal(el).show(); }
+        });
+      </script>
+      {% endif %}
+
+      {# Existing tokens table #}
+      {% if scim_tokens %}
+      <div class="table-responsive mb-4">
+        <table class="table table-striped table-sm align-middle">
+          <thead>
+            <tr>
+              <th>Description</th>
+              <th>Domain restriction</th>
+              <th>Template</th>
+              <th>IP allow list</th>
+              <th>Active</th>
+              <th>Created</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for token in scim_tokens %}
+            <tr>
+              <td>{{ token.description }}</td>
+              <td>{{ token.domain_restriction ?? '(all domains)' }}</td>
+              <td>{{ token.template ?? '(default)' }}</td>
+              <td>
+                {% if token.skip_ip_check %}
+                  <em>Any</em>
+                {% else %}
+                  <code>{{ token.allow_from ?: '(any)' }}</code>
+                {% endif %}
+              </td>
+              <td>
+                <form method="post" class="d-inline">
+                  <input type="hidden" name="edit_scim_token" value="1">
+                  <input type="hidden" name="id" value="{{ token.id }}">
+                  <input type="hidden" name="description" value="{{ token.description }}">
+                  <input type="hidden" name="domain_restriction" value="{{ token.domain_restriction }}">
+                  <input type="hidden" name="template" value="{{ token.template }}">
+                  <input type="hidden" name="allow_from" value="{{ token.allow_from }}">
+                  <input type="hidden" name="skip_ip_check" value="{{ token.skip_ip_check }}">
+                  <input type="hidden" name="active" value="{{ token.active ? 0 : 1 }}">
+                  <button type="submit" class="btn btn-xs btn-{{ token.active ? 'success' : 'secondary' }}">
+                    {{ token.active ? 'Active' : 'Inactive' }}
+                  </button>
+                </form>
+              </td>
+              <td>{{ token.created }}</td>
+              <td>
+                <form method="post" class="d-inline" onsubmit="return confirm('Delete this SCIM token?')">
+                  <input type="hidden" name="delete_scim_token" value="1">
+                  <input type="hidden" name="id" value="{{ token.id }}">
+                  <button type="submit" class="btn btn-xs btn-danger"><i class="bi bi-trash"></i></button>
+                </form>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <p class="text-muted offset-sm-3 mb-4">No SCIM tokens configured yet.</p>
+      {% endif %}
+
+      {# Add token form #}
+      <div class="card mb-3">
+        <div class="card-header">Add SCIM Token</div>
+        <div class="card-body">
+          <form method="post" autocomplete="off">
+            <input type="hidden" name="add_scim_token" value="1">
+
+            <div class="row mb-2">
+              <div class="col-md-3 d-flex align-items-center justify-content-md-end">
+                <label class="control-label">Description</label>
+              </div>
+              <div class="col-12 col-md-9 col-lg-4">
+                <input type="text" class="form-control" name="description" placeholder="e.g. Keycloak production" required>
+              </div>
+            </div>
+
+            <div class="row mb-2">
+              <div class="col-md-3 d-flex align-items-center justify-content-md-end">
+                <label class="control-label">Domain restriction <small class="text-muted">(optional)</small></label>
+              </div>
+              <div class="col-12 col-md-9 col-lg-4">
+                <input type="text" class="form-control" name="domain_restriction" placeholder="example.com (leave blank for all domains)">
+              </div>
+            </div>
+
+            <div class="row mb-2">
+              <div class="col-md-3 d-flex align-items-center justify-content-md-end">
+                <label class="control-label">Mailbox template <small class="text-muted">(optional)</small></label>
+              </div>
+              <div class="col-12 col-md-9 col-lg-4">
+                <select class="form-control" name="template">
+                  <option value="">(Use system defaults)</option>
+                  {% for tmpl in mbox_templates %}
+                  <option value="{{ tmpl.template }}">{{ tmpl.template }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+            </div>
+
+            <div class="row mb-2">
+              <div class="col-md-3 d-flex align-items-center justify-content-md-end">
+                <label class="control-label">IP allow list <small class="text-muted">(optional)</small></label>
+              </div>
+              <div class="col-12 col-md-9 col-lg-4">
+                <input type="text" class="form-control" name="allow_from" placeholder="192.168.1.0/24, 10.0.0.1">
+                <div class="form-check mt-1">
+                  <input class="form-check-input" type="checkbox" name="skip_ip_check" value="1" id="scim_skip_ip_check">
+                  <label class="form-check-label" for="scim_skip_ip_check">Allow from any IP</label>
+                </div>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="col-md-9 offset-md-3">
+                <button type="submit" class="btn btn-success"><i class="bi bi-plus-lg"></i> Generate token</button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/data/web/templates/admin/tab-config-scim.twig
+++ b/data/web/templates/admin/tab-config-scim.twig
@@ -74,13 +74,7 @@
               <td>{{ token.description }}</td>
               <td>{{ token.domain_restriction ?? '(all domains)' }}</td>
               <td>{{ token.template ?? '(default)' }}</td>
-              <td>
-                {% if token.skip_ip_check %}
-                  <em>Any</em>
-                {% else %}
-                  <code>{{ token.allow_from ?: '(any)' }}</code>
-                {% endif %}
-              </td>
+              <td><code>{{ token.allow_from ?: '(any)' }}</code></td>
               <td>
                 <form method="post" class="d-inline">
                   <input type="hidden" name="edit_scim_token" value="1">
@@ -89,7 +83,6 @@
                   <input type="hidden" name="domain_restriction" value="{{ token.domain_restriction }}">
                   <input type="hidden" name="template" value="{{ token.template }}">
                   <input type="hidden" name="allow_from" value="{{ token.allow_from }}">
-                  <input type="hidden" name="skip_ip_check" value="{{ token.skip_ip_check }}">
                   <input type="hidden" name="active" value="{{ token.active ? 0 : 1 }}">
                   <button type="submit" class="btn btn-xs btn-{{ token.active ? 'success' : 'secondary' }}">
                     {{ token.active ? 'Active' : 'Inactive' }}
@@ -158,10 +151,6 @@
               </div>
               <div class="col-12 col-md-9 col-lg-4">
                 <input type="text" class="form-control" name="allow_from" placeholder="192.168.1.0/24, 10.0.0.1">
-                <div class="form-check mt-1">
-                  <input class="form-check-input" type="checkbox" name="skip_ip_check" value="1" id="scim_skip_ip_check">
-                  <label class="form-check-label" for="scim_skip_ip_check">Allow from any IP</label>
-                </div>
               </div>
             </div>
 

--- a/data/web/templates/admin/tab-config-scim.twig
+++ b/data/web/templates/admin/tab-config-scim.twig
@@ -13,6 +13,9 @@
         provisioning events to mailcow in real time. Generate a Bearer token below and configure your
         IdP to use <code>{{ scim_base_url }}</code>
         as the SCIM base URL.
+        Mailbox templates can be selected per user via the <code>template</code> attribute of the
+        <code>urn:mailcow:params:scim:schemas:extension:mailcow:2.0:User</code> schema extension,
+        mapped to a mailcow mailbox template in the &laquo;Attribute mapping&raquo; table.
       </p>
 
       {% if iam_settings.authsource != 'keycloak' and iam_settings.authsource != 'generic-oidc' and iam_settings.authsource != 'ldap' %}
@@ -101,11 +104,25 @@
 
                 <div class="row mb-2">
                   <div class="col-md-3 d-flex align-items-center justify-content-md-end">
+                    <label class="control-label">Claim pre-created mailboxes</label>
+                  </div>
+                  <div class="col-12 col-md-9">
+                    <div class="form-check pt-1">
+                      <input class="form-check-input" type="checkbox" name="allow_claim" value="1" id="scimEditAllowClaim">
+                      <label class="form-check-label" for="scimEditAllowClaim">
+                        <small class="text-muted">Allow POST /Users to adopt existing mailboxes with authsource &laquo;SCIM&raquo; instead of returning 409 Conflict</small>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="row mb-2">
+                  <div class="col-md-3 d-flex align-items-center justify-content-md-end">
                     <label class="control-label">Attribute mapping</label>
                   </div>
                   <div class="col-12 col-md-9 col-lg-6">
                     <div class="row px-2 align-items-center mb-1">
-                      <span class="col-5 p-0 pe-2"><small class="text-muted">mailcow_template value</small></span>
+                      <span class="col-5 p-0 pe-2"><small class="text-muted">template attribute value</small></span>
                       <span class="col-5 p-0 pe-2"><small class="text-muted">Mailbox template</small></span>
                       <div class="col-2 p-0 d-flex">
                         <button type="button" class="btn btn-sm btn-secondary ms-auto scim_rolemap_add"><i class="bi bi-plus-lg"></i></button>
@@ -174,6 +191,7 @@
                   <input type="hidden" name="allow_from" value="{{ token.allow_from }}">
                   <input type="hidden" name="mappers" value="{{ token.mappers }}">
                   <input type="hidden" name="templates" value="{{ token.templates }}">
+                  <input type="hidden" name="allow_claim" value="{{ token.allow_claim }}">
                   <input type="hidden" name="active" value="{{ token.active ? 0 : 1 }}">
                   <button type="submit" class="btn btn-xs btn-{{ token.active ? 'success' : 'secondary' }}">
                     {{ token.active ? 'Active' : 'Inactive' }}
@@ -191,6 +209,7 @@
                   data-allow-from="{{ token.allow_from }}"
                   data-mappers="{{ token.mappers }}"
                   data-templates="{{ token.templates }}"
+                  data-allow-claim="{{ token.allow_claim }}"
                   data-active="{{ token.active }}">
                   <i class="bi bi-pencil"></i>
                 </button>
@@ -241,7 +260,7 @@
               </div>
               <div class="col-12 col-md-9 col-lg-4">
                 <div class="row px-2 align-items-center mb-1">
-                  <span class="col-5 p-0 pe-2"><small class="text-muted">mailcow_template value</small></span>
+                  <span class="col-5 p-0 pe-2"><small class="text-muted">template attribute value</small></span>
                   <span class="col-5 p-0 pe-2"><small class="text-muted">Mailbox template</small></span>
                   <div class="col-2 p-0 d-flex">
                     <button type="button" class="btn btn-sm btn-secondary ms-auto scim_rolemap_add_new"><i class="bi bi-plus-lg"></i></button>
@@ -274,6 +293,20 @@
               </div>
               <div class="col-12 col-md-9 col-lg-4">
                 <input type="text" class="form-control" name="allow_from" placeholder="192.168.1.0/24, 10.0.0.1">
+              </div>
+            </div>
+
+            <div class="row mb-2">
+              <div class="col-md-3 d-flex align-items-center justify-content-md-end">
+                <label class="control-label">Claim pre-created mailboxes</label>
+              </div>
+              <div class="col-12 col-md-9 col-lg-4">
+                <div class="form-check pt-1">
+                  <input class="form-check-input" type="checkbox" name="allow_claim" value="1" id="scim_add_allow_claim">
+                  <label class="form-check-label" for="scim_add_allow_claim">
+                    <small class="text-muted">Allow POST /Users to adopt existing mailboxes with authsource &laquo;SCIM&raquo; instead of returning 409 Conflict</small>
+                  </label>
+                </div>
               </div>
             </div>
 

--- a/data/web/templates/edit/mailbox.twig
+++ b/data/web/templates/edit/mailbox.twig
@@ -43,6 +43,9 @@
                           {% if iam_settings.authsource == 'ldap' %}
                           <option value="ldap" {% if result.authsource == "ldap" %}selected{% endif %}>LDAP</option>
                           {% endif %}
+                          {% if scim_tokens is not empty or result.authsource == "scim" %}
+                          <option value="scim" {% if result.authsource == "scim" %}selected{% endif %}>SCIM</option>
+                          {% endif %}
                       </select>
                     </div>
                   </div>


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Implements a SCIM 2.0 (RFC 7643/7644) server endpoint so any Identity Provider — Keycloak, Entra ID, Okta, or any LDAP/OIDC IdP — can push user lifecycle events to mailcow in real time, independently of whichever login protocol is configured.

#### Protocol support

- Full Users CRUD: POST, GET, PUT, PATCH (RFC 7644 §3.5.2), DELETE
- SCIM DELETE is a soft-deactivate (active=0); mail data is never removed
- Filtering: filter=userName eq "..." on list endpoint
- Pagination: startIndex / count
- Discovery: ServiceProviderConfig, Schemas, ResourceTypes
- Groups: out of scope

#### Authentication & token management

Bearer tokens are generated in the admin UI (System > Configuration > Access > SCIM). The raw token is shown once at creation and never stored; only its SHA-256 hash is kept. Each token supports:
- Optional domain restriction (limits which mailboxes the token can manage)
- Optional mailbox template (applied on user creation)
- Optional IP allow-list / skip-IP-check flag
- Active/inactive toggle

#### Database schema

Two new tables added via the existing init_db migration mechanism:
- scim_tokens: stores token metadata and hashed credentials
- scim_maps: maps IdP externalId values to mailcow usernames per token The mailbox.authsource ENUM is extended with 'scim'.

#### Authsource & login design

SCIM is a provisioning protocol, not an authentication protocol. mailbox.authsource='scim' records who manages the user; login is handled by the globally configured IAM provider:

- Keycloak / Generic-OIDC: SCIM users pass through the existing verify-sso OIDC flow (identity_provider 'verify-sso' case).
- LDAP: SCIM users authenticate via ldap_mbox_login(), with full TFA support, matching the behaviour of authsource='ldap' users.
- No IAM configured: SCIM users cannot log in; the admin UI shows a warning on the SCIM configuration tab.

Attempting a password login as a SCIM user when an OIDC provider is configured returns a clear error directing the user to their IdP.

#### Claiming pre-existing users

A SCIM POST for a user who already has authsource='scim' (e.g. set manually by the admin to prepare a migration) is treated as a claim: attributes are updated, scim_maps is upserted, and 200 is returned. A SCIM POST for a user managed by a different authsource returns 409 with an actionable message explaining how to transfer ownership.

#### Admin UI

- New SCIM tab under System > Configuration > Access (alongside Identity Provider settings)
- Token table with active toggle and delete; one-time raw token modal
- Mailbox edit form gains a SCIM authsource option, shown only when SCIM tokens exist (or the mailbox is already set to SCIM)
- Contextual warning when no external IdP is configured for login

###  Affected Containers

- php-fpm-mailcow
- nginx-mailcow (nginx configuration template)
- sogo-mailcow (shared DB initialisation file)

## Did you run tests?

### What did you tested?

- User creation, updating, deactivation via SCIM
- General SCIM protocol testing
- Migration between mailcow/external IdP and SCIM
- Logging-in in various scenarios
- Invalid SCIM requests (updating non-SCIM users to test the error handling)
- Admin UI test (create/update/delete SCIM tokens)

### What were the final results? (Awaited, got)

All the tests gave results conforming to the described behaviours.