### PR TITLE
Changed default role for calendar access to show only date and time.

### DIFF
--- a/data/conf/sogo/sogo.conf
+++ b/data/conf/sogo/sogo.conf
@@ -1,6 +1,6 @@
 {
     SOGoCalendarDefaultRoles = (
-        PublicViewer,
+        PublicDAndTViewer,
         ConfidentialDAndTViewer,
         PrivateDAndTViewer
     );


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?


### Short Description

Currently the default calendar shareing permissions in SOGo for events marked as "public" in a personal calendar are set to "ViewAll" for all users in the same domain.
In addition by default new events are created as "public". That results in all users within a domain/org can read events of all other users by default.

To improve security I think the default should be changed to allow only to see date/time of an event ("free/busy"). Every user then still can set sharing permissions individually as needed.

Current default calendar sharing permission:
<img width="241" height="278" alt="SOGo_Kalenderfreigabe1a_EN" src="https://github.com/user-attachments/assets/2daf752d-6499-47f9-90c4-6b1c08df2561" />

Proposed change:
<img width="234" height="276" alt="SOGo_Kalenderfreigabe2a_EN" src="https://github.com/user-attachments/assets/a70a3eb1-6091-4a36-8cee-07c648944b7b" />


###  Affected Containers

- sogo-mailcow

## Did you run tests?

### What did you tested?

Edited file ```data/conf/sogo/sogo.conf``` and changed

```conf
SOGoCalendarDefaultRoles = (
  PublicViewer,
  ConfidentialDAndTViewer,
  PrivateDAndTViewer
);
```

to this:
```conf
SOGoCalendarDefaultRoles = (
  PublicDAndTViewer,
  ConfidentialDAndTViewer,
  PrivateDAndTViewer
);
```
Restarted containers sogo-mailcow and memcached-mailcow:
```bash
docker compose restart sogo-mailcow memcached-mailcow
```

### What were the final results? (Awaited, got)

Works as intendet: the default calendar sharing permissions for new and existing users are set to show date & time only ("free/busy") for events marked as public. Users can change shareing permisisons as they like. In case a user already has changed sharing permissions before, those individual permissions are not changed.
