### PR TITLE
Update HSTS max-age to 31536000 seconds

### DIFF
--- a/data/conf/nginx/templates/sites-default.conf.j2
+++ b/data/conf/nginx/templates/sites-default.conf.j2
@@ -12,7 +12,7 @@ ssl_session_cache shared:SSL:50m;
 ssl_session_timeout 1d;
 ssl_session_tickets off;
 
-add_header Strict-Transport-Security "max-age=15768000;";
+add_header Strict-Transport-Security "max-age=31536000;";
 add_header X-Content-Type-Options nosniff;
 add_header X-Robots-Tag none;
 add_header X-Download-Options noopen;


### PR DESCRIPTION

<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

The recommendation is to use at least 1 year for this value, which is checked by scanners such as https://internet.nl/.

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

-->

- nginx

## Did you run tests?

No

### What did you tested?

Quick edit using Github UI, as it is only a small HSTS max-age change.

### What were the final results? (Awaited, got)

-