### PR TITLE
fix: disable default rspamd clamav integration when SKIP_CLAMD=y

### DIFF
--- a/_modules/scripts/new_options.sh
+++ b/_modules/scripts/new_options.sh
@@ -280,7 +280,7 @@ adapt_new_options() {
             echo ENABLE_IPV6=${IPV6_BOOL} >> mailcow.conf
             ;;
         SKIP_CLAMD)
-            echo '# Skip ClamAV (clamd-mailcow) anti-virus (Rspamd will auto-detect a missing ClamAV container) - y/n' >> mailcow.conf
+            echo '# Skip ClamAV (clamd-mailcow) anti-virus - y/n' >> mailcow.conf
             echo 'SKIP_CLAMD=n' >> mailcow.conf
             ;;
         SKIP_OLEFY)

--- a/data/Dockerfiles/rspamd/docker-entrypoint.sh
+++ b/data/Dockerfiles/rspamd/docker-entrypoint.sh
@@ -104,6 +104,21 @@ EOF
   fi
 fi
 
+CLAMD_AUTO_DISABLE_CONF=/etc/rspamd/override.d/antivirus.conf
+if [[ "${SKIP_CLAMD}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+  # Only auto-disable when antivirus.conf still points to the default local Mailcow
+  # ClamAV target. This avoids breaking custom external ClamAV setups.
+  if grep -Eq '^[[:space:]]*servers[[:space:]]*=[[:space:]]*"clamd:3310";' /etc/rspamd/local.d/antivirus.conf 2>/dev/null; then
+    cat <<EOF > "${CLAMD_AUTO_DISABLE_CONF}"
+clamav {
+  enabled = false;
+}
+EOF
+  fi
+else
+  rm -f "${CLAMD_AUTO_DISABLE_CONF}"
+fi
+
 # Provide additional lua modules
 ln -s /usr/lib/$(uname -m)-linux-gnu/liblua5.1-cjson.so.0.0.0 /usr/lib/rspamd/cjson.so
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
         - REDIS_SLAVEOF_PORT=${REDIS_SLAVEOF_PORT:-}
         - REDISPASS=${REDISPASS}
         - SPAMHAUS_DQS_KEY=${SPAMHAUS_DQS_KEY:-}
+        - SKIP_CLAMD=${SKIP_CLAMD:-n}
       volumes:
         - ./data/hooks/rspamd:/hooks:Z
         - ./data/conf/rspamd/custom/:/etc/rspamd/custom:z

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -322,7 +322,7 @@ SKIP_HTTP_VERIFICATION=n
 # Skip Unbound (DNS Resolver) Healthchecks (NOT Recommended!) - y/n
 SKIP_UNBOUND_HEALTHCHECK=n
 
-# Skip ClamAV (clamd-mailcow) anti-virus (Rspamd will auto-detect a missing ClamAV container) - y/n
+# Skip ClamAV (clamd-mailcow) anti-virus - y/n
 SKIP_CLAMD=${SKIP_CLAMD}
 
 # Skip Olefy (olefy-mailcow) anti-virus for Office documents (Rspamd will auto-detect a missing Olefy container) - y/n


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

### Short Description

Disable the default Rspamd ClamAV integration when SKIP_CLAMD=y, so Rspamd stops trying to scan via clamd:3310 and no longer logs ClamAV timeout warnings. 

###  Affected Containers

- rspamd-mailcow
 
## Did you run tests?

### What did you tested?

- Verified rspamd-mailcow receives SKIP_CLAMD
- Verified the hook creates /etc/rspamd/override.d/antivirus.conf
- Verified rspamadm configdump antivirus shows clamav { enabled = false; }
- Sent a test mail through SMTP on a live Mailcow setup
- Checked rspamd-mailcow logs before and after the change

### What were the final results? (Awaited, got)

- Awaited: with SKIP_CLAMD=y, Rspamd should stop using the default ClamAV scanner and stop logging CLAM_VIRUS_FAIL / maximum retransmits exceed
- Got: the clamav module was disabled in effective config, and the test mail was processed without ClamAV timeout warnings or CLAM_VIRUS_FAIL
