### PR TITLE
Escape generated password in mobileconfig

### DIFF
--- a/data/web/mobileconfig.php
+++ b/data/web/mobileconfig.php
@@ -52,7 +52,7 @@ if (isset($_GET['app_password'])) {
   else
       $platform = $_SERVER['HTTP_USER_AGENT'];
 
-  $password = password_generate();
+  $password = htmlspecialchars(password_generate(), ENT_NOQUOTES);
 
   $attr = array(
       'app_name' => $platform,

--- a/data/web/mobileconfig.php
+++ b/data/web/mobileconfig.php
@@ -65,6 +65,7 @@ if (isset($_GET['app_password'])) {
       $attr['protocols'][] = 'dav_access';
   }
   app_passwd("add", $attr);
+  $password = htmlspecialchars($password, ENT_NOQUOTES);
 } else {
   $app_password = false;
 }


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

Fix #7171

### Short Description

Escape ampersand, less than, greater than to avoid generating invalid mobileconfig XML.

###  Affected Containers

phpfpm

## Did you run tests?

yes

### What did you tested?

generated mobileconfig

### What were the final results? (Awaited, got)

got syntactically valid XML