### PR TITLE
[Web] escape HTML in sieve filter edit view and queue manager

### DIFF
--- a/data/web/js/site/queue.js
+++ b/data/web/js/site/queue.js
@@ -48,13 +48,13 @@ jQuery(function($){
       url: "/api/v1/get/mailq/all",
       dataSrc: function(data){
         $.each(data, function (i, item) {
-          item.chkbox = '<input type="checkbox" class="form-check-input" data-id="mailqitems" name="multi_select" value="' + item.queue_id + '" />';
+          item.chkbox = '<input type="checkbox" class="form-check-input" data-id="mailqitems" name="multi_select" value="' + escapeHtml(item.queue_id) + '" />';
           rcpts = $.map(item.recipients, function(i) {
             return escapeHtml(i);
           });
           item.recipients = rcpts.join('<hr style="margin:1px!important">');
           item.action = '<div class="btn-group">' +
-            '<a href="#" data-bs-toggle="modal" data-bs-target="#showQueuedMsg" data-queue-id="' + encodeURI(item.queue_id) + '" class="btn btn-xs btn-secondary">' + lang.show_message + '</a>' +
+            '<a href="#" data-bs-toggle="modal" data-bs-target="#showQueuedMsg" data-queue-id="' + escapeHtml(item.queue_id) + '" class="btn btn-xs btn-secondary">' + lang.show_message + '</a>' +
             '</div>';
           });
           return data;
@@ -79,12 +79,14 @@ jQuery(function($){
         {
           title: 'QID',
           data: 'queue_id',
-          defaultContent: ''
+          defaultContent: '',
+          render: $.fn.dataTable.render.text()
         },
         {
           title: 'Queue',
           data: 'queue_name',
-          defaultContent: ''
+          defaultContent: '',
+          render: $.fn.dataTable.render.text()
         },
         {
           title: lang_admin.arrival_time,
@@ -106,7 +108,8 @@ jQuery(function($){
         {
           title: lang_admin.sender,
           data: 'sender',
-          defaultContent: ''
+          defaultContent: '',
+          render: $.fn.dataTable.render.text()
         },
         {
           title: lang_admin.recipients,

--- a/data/web/templates/edit/filter.twig
+++ b/data/web/templates/edit/filter.twig
@@ -23,7 +23,7 @@
   <div class="row mb-4">
     <label class="control-label col-sm-2" for="script_data">Script:</label>
     <div class="col-sm-10">
-      <textarea spellcheck="false" autocorrect="off" autocapitalize="none" class="form-control textarea-code" rows="20" id="script_data" name="script_data" required>{{ result.script_data|raw }}</textarea>
+      <textarea spellcheck="false" autocorrect="off" autocapitalize="none" class="form-control textarea-code" rows="20" id="script_data" name="script_data" required>{{ result.script_data }}</textarea>
     </div>
   </div>
   <div class="row mb-2">


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Two small UI fixes that align user-controlled values with the auto-escaping pattern already used elsewhere:

- `edit/filter.twig`: drop `|raw` on `script_data`.
- `js/site/queue.js`: route `queue_id`, `queue_name`, `sender` through the DataTables text renderer; HTML-escape `queue_id` in the inline checkbox and action link.

### Affected Containers

- php-fpm-mailcow

