### PR TITLE
[Nginx] Update to 1.30.1

### DIFF
--- a/data/Dockerfiles/nginx/Dockerfile
+++ b/data/Dockerfiles/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.30.1-alpine
 LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
 
 ENV PIP_BREAK_SYSTEM_PACKAGES=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -419,7 +419,7 @@ services:
         - php-fpm-mailcow
         - sogo-mailcow
         - rspamd-mailcow
-      image: ghcr.io/mailcow/nginx:1.06
+      image: ghcr.io/mailcow/nginx:1.30.1-1
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       environment:


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Pin nginx base image to `1.30.1-alpine`.

### Affected Containers

- nginx-mailcow

## Did you run tests?

### What did you tested?

Built and started the container, verified `nginx -v` reports 1.30.1,
checked web UI and SOGo.
