### PR TITLE
escape HTML in quarantine table

### DIFF
--- a/data/web/js/site/quarantine.js
+++ b/data/web/js/site/quarantine.js
@@ -102,18 +102,21 @@ jQuery(function($){
         {
           title: 'ID',
           data: 'id',
-          defaultContent: ''
+          defaultContent: '',
+          render: $.fn.dataTable.render.text()
         },
         {
           title: lang.qid,
           data: 'qid',
-          defaultContent: ''
+          defaultContent: '',
+          render: $.fn.dataTable.render.text()
         },
         {
           title: lang.sender,
           data: 'sender',
           className: 'senders-mw220',
-          defaultContent: ''
+          defaultContent: '',
+          render: $.fn.dataTable.render.text()
         },
         {
           title: lang.subj,
@@ -128,7 +131,8 @@ jQuery(function($){
         {
           title: lang.rcpt,
           data: 'rcpt',
-          defaultContent: ''
+          defaultContent: '',
+          render: $.fn.dataTable.render.text()
         },
         {
           title: lang.danger,


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

small UI fix that align user-controlled values with the auto-escaping pattern already used elsewhere:

- `js/site/quarantine.js`: route `id`, `qid`, `sender`, `rcpt` through the DataTables text renderer

### Affected Containers

- php-fpm-mailcow

