### PR TITLE
Fix XML escaping for mobileconfig app passwords

### DIFF
--- a/data/web/mobileconfig.php
+++ b/data/web/mobileconfig.php
@@ -15,6 +15,10 @@ if (!isset($_SESSION['mailcow_cc_role']) || $_SESSION['mailcow_cc_role'] != 'use
 
 error_reporting(0);
 
+function mobileconfig_xml_escape($value) {
+  return htmlspecialchars((string)$value, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
 header('Content-Type: application/x-apple-aspen-config');
 header('Content-Disposition: attachment; filename="'.$UI_TEXTS['main_name'].'.mobileconfig"');
 
@@ -97,7 +101,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
         <string><?=$email?></string>
         <?php if($app_password === true): ?>
         <key>IncomingPassword</key>
-        <string><?=$password?></string>
+        <string><?=mobileconfig_xml_escape($password)?></string>
         <?php endif; ?>
         <key>OutgoingMailServerAuthentication</key>
         <string>EmailAuthPassword</string>
@@ -156,7 +160,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
         <string><?=$email?></string>
         <?php if($app_password === true): ?>
         <key>CalDAVPassword</key>
-        <string><?=$password?></string>
+        <string><?=mobileconfig_xml_escape($password)?></string>
         <?php endif; ?>
         <key>PayloadDescription</key>
         <string>Configures CalDAV account.</string>
@@ -188,7 +192,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
         <string><?=$email?></string>
         <?php if($app_password === true): ?>
         <key>CardDAVPassword</key>
-        <string><?=$password?></string>
+        <string><?=mobileconfig_xml_escape($password)?></string>
         <?php endif; ?>
         <key>PayloadDescription</key>
         <string>Configures CardDAV accounts</string>


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?
Small bug fix for mobileconfigs with app generated passwords containing ampersands.

### Short Description

<!-- Please write a short description, what your PR does here. -->
Escape HTML special characters in passwords during mobileconfig generation. 

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- php-fpm-mailcow

## Did you run tests?

### What did you tested?

I tested the mobile profile generation. Steps:
* Log in as a mail user, go to mailcow preferences
* Next to "Apple connection profile with app password", click the profile links repeatedly until an a profile with an & in the password is generated (~10x is typically sufficient)
* Open the configuration profile, confirm that it has &amp; instead of & inside the XML
* Open the configuration profile on macOS/iOS, confirm that it opens successfully.

<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)
Profiles with & in the password now open successfully.

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->