### PR TITLE
ui, fail2ban fix german ban_list_info translation

### DIFF
--- a/data/web/lang/lang.de-de.json
+++ b/data/web/lang/lang.de-de.json
@@ -150,7 +150,7 @@
         "arrival_time": "Ankunftszeit (Serverzeit)",
         "authed_user": "Auth. Benutzer",
         "ays": "Soll der Vorgang wirklich ausgeführt werden?",
-        "ban_list_info": "Übersicht ausgesperrter Netzwerke: <b>Netzwerk (verbleibende Bannzeit) - [Aktionen]</b>.<br />IPs, die zum Entsperren eingereiht werden, verlassen die Liste aktiver Banns nach wenigen Sekunden.<br />Rote Labels sind Indikatoren für aktive Allowlist-Einträge.",
+        "ban_list_info": "Übersicht ausgesperrter Netzwerke: <b>Netzwerk (verbleibende Bannzeit) - [Aktionen]</b>.<br />IPs, die zum Entsperren eingereiht werden, verlassen die Liste aktiver Banns nach wenigen Sekunden.<br />Rote Labels kennzeichnen aktive permanente Sperren durch Denylisting.",
         "change_logo": "Logo ändern",
         "configuration": "Konfiguration",
         "convert_html_to_text": "Konvertiere HTML zu reinem Text",


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?
Just a small translation fix

### Short Description
A small translation fix for the fail2ban `ban_list_info` german translation
<!-- Please write a short description, what your PR does here. -->

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

- nginx-mailcow

## Did you run tests?
Just manually checked the UI

### What did you tested?
Tested like described in the issue:
German UI shows ‘Allowlist’ in Fail2Ban view, should be ‘Denylist’ like EN/ES.“
<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)
got, correct german translation as expected.

<img width="1349" height="491" alt="image" src="https://github.com/user-attachments/assets/2e9358c2-d649-4880-95c1-1451140a6127" />


Ref: #7264