### PR TITLE
Use string 'true' for the 'exact' query parameter to retrieve users f…

### DIFF
--- a/data/web/inc/functions.auth.inc.php
+++ b/data/web/inc/functions.auth.inc.php
@@ -515,7 +515,7 @@ function keycloak_mbox_login_rest($user, $pass, $extra = null){
 
   // get the mailcow_password attribute from keycloak user
   $url = "{$iam_settings['server_url']}/admin/realms/{$iam_settings['realm']}/users";
-  $queryParams = array('email' => $user, 'exact' => true);
+  $queryParams = array('email' => $user, 'exact' => 'true');
   $queryString = http_build_query($queryParams);
   $curl = curl_init();
   curl_setopt($curl, CURLOPT_TIMEOUT, 7);


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

**Problem:** The _exact_ parameter value _true_ in the Keycloak user query in _keycloak_mbox_login_rest_ is converted to query parameter 1, which Keycloak interprets as “false”. Keycloak then performs a wildcard search (%$email%) and may return multiple users. This could allow a user to log in to another user’s account using their own password.

<img width="2511" height="1221" alt="keycloak_users_exact_1" src="https://github.com/user-attachments/assets/21a62293-b57a-434b-b6f5-b72e6d3cba79" />

**Solution:**: Change exact parameter value from true (1) to 'true'.

###  Affected Containers

- php-fpm-mailcow

## Did you run tests?

### What did you tested?

IMAP logins using Keycloak users who have set a _mailcow_password_ attribute.

### What were the final results? (Awaited, got)

All users were able to log in using their own password.

<img width="2498" height="992" alt="keycloak_users_exact_true" src="https://github.com/user-attachments/assets/b49c525b-c46f-4ccb-816d-aa8243ec54ce" />
