### PR TITLE
Fix force_tfa not available in mailbox template #7216

### DIFF
--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -1072,6 +1072,7 @@ paths:
                           password2: "*"
                           quota: "3072"
                           force_pw_update: "1"
+                          force_tfa: "1"
                           tls_enforce_in: "1"
                           tls_enforce_out: "1"
                           tags: ["tag1", "tag2"]
@@ -1118,6 +1119,7 @@ paths:
                 password2: atedismonsin
                 quota: "3072"
                 force_pw_update: "1"
+                force_tfa: "1"
                 tls_enforce_in: "1"
                 tls_enforce_out: "1"
                 tags: ["tag1", "tag2"]
@@ -1150,6 +1152,9 @@ paths:
                   type: number
                 force_pw_update:
                   description: forces the user to update its password on first login
+                  type: boolean
+                force_tfa:
+                  description: force 2FA enrollment at login
                   type: boolean
                 tls_enforce_in:
                   description: force inbound email tls encryption
@@ -2510,7 +2515,7 @@ paths:
       description: >-
         Using this endpoint you can perform actions on quarantine items. It is possible to release
         emails from quarantine into to the inbox, or learn them as ham to improve Rspamd filtering.
-        You must provide the quarantine item IDs. You can get the IDs using the GET method.      
+        You must provide the quarantine item IDs. You can get the IDs using the GET method.
       operationId: Edit mails in Quarantine
       requestBody:
         content:
@@ -3414,6 +3419,7 @@ paths:
                         - mailbox
                         - active: "1"
                           force_pw_update: "0"
+                          force_tfa: "0"
                           name: Full name
                           password: "*"
                           password2: "*"
@@ -3464,6 +3470,7 @@ paths:
                 attr:
                   active: "1"
                   force_pw_update: "0"
+                  force_tfa: "0"
                   name: Full name
                   authsource: mailcow
                   password: ""
@@ -3486,6 +3493,9 @@ paths:
                       type: boolean
                     force_pw_update:
                       description: force user to change password on next login
+                      type: boolean
+                    force_tfa:
+                      description: force 2FA enrollment at login
                       type: boolean
                     name:
                       description: Full name of the mailbox user
@@ -4881,6 +4891,7 @@ paths:
                     - active: "1"
                       attributes:
                         force_pw_update: "0"
+                        force_tfa: "0"
                         mailbox_format: "maildir:"
                         quarantine_notification: never
                         sogo_access: "1"
@@ -5805,6 +5816,7 @@ paths:
                     - active: "1"
                       attributes:
                         force_pw_update: "0"
+                        force_tfa: "0"
                         mailbox_format: "maildir:"
                         quarantine_notification: never
                         sogo_access: "1"

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -3828,6 +3828,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             $attr["rl_frame"]                    = (!empty($_data['rl_frame'])) ? $_data['rl_frame'] : $is_now['rl_frame'];
             $attr["rl_value"]                    = (!empty($_data['rl_value'])) ? $_data['rl_value'] : $is_now['rl_value'];
             $attr["force_pw_update"]             = isset($_data['force_pw_update']) ? intval($_data['force_pw_update']) : $is_now['force_pw_update'];
+            $attr["force_tfa"]                   = isset($_data['force_tfa']) ? intval($_data['force_tfa']) : $is_now['force_tfa'];
             $attr["sogo_access"]                 = isset($_data['sogo_access']) ? intval($_data['sogo_access']) : $is_now['sogo_access'];
             $attr["active"]                      = isset($_data['active']) ? intval($_data['active']) : $is_now['active'];
             $attr["tls_enforce_in"]              = isset($_data['tls_enforce_in']) ? intval($_data['tls_enforce_in']) : $is_now['tls_enforce_in'];

--- a/data/web/js/site/mailbox.js
+++ b/data/web/js/site/mailbox.js
@@ -424,6 +424,11 @@ $(document).ready(function() {
     } else {
       $('#force_pw_update').prop('checked', false);
     }
+    if (template.force_tfa == 1){
+      $('#force_tfa').prop('checked', true);
+    } else {
+      $('#force_tfa').prop('checked', false);
+    }
     if (template.sogo_access == 1){
       $('#sogo_access').prop('checked', true);
     } else {
@@ -1242,6 +1247,7 @@ jQuery(function($){
             item.attributes.eas_access = '<i class="text-' + (item.attributes.eas_access == 1 ? 'success' : 'danger') + ' bi bi-' + (item.attributes.eas_access == 1 ? 'check-lg' : 'x-lg') + '"><span class="sorting-value">' + (item.attributes.eas_access == 1 ? '1' : '0') + '</span></i>';
             item.attributes.dav_access = '<i class="text-' + (item.attributes.dav_access == 1 ? 'success' : 'danger') + ' bi bi-' + (item.attributes.dav_access == 1 ? 'check-lg' : 'x-lg') + '"><span class="sorting-value">' + (item.attributes.dav_access == 1 ? '1' : '0') + '</span></i>';
             item.attributes.sogo_access = '<i class="text-' + (item.attributes.sogo_access == 1 ? 'success' : 'danger') + ' bi bi-' + (item.attributes.sogo_access == 1 ? 'check-lg' : 'x-lg') + '"><span class="sorting-value">' + (item.attributes.sogo_access == 1 ? '1' : '0') + '</span></i>';
+            item.attributes.force_tfa = '<i class="text-' + (item.attributes.force_tfa == 1 ? 'success' : 'danger') + ' bi bi-' + (item.attributes.force_tfa == 1 ? 'check-lg' : 'x-lg') + '"><span class="sorting-value">' + (item.attributes.force_tfa == 1 ? '1' : '0') + '</span></i>';
             if (item.attributes.quarantine_notification === 'never') {
               item.attributes.quarantine_notification = lang.never;
             } else if (item.attributes.quarantine_notification === 'hourly') {
@@ -1384,6 +1390,11 @@ jQuery(function($){
           render: function (data, type) {
             return 1==data?'<i class="bi bi-check-lg"></i>':'<i class="bi bi-x-lg"></i>';
           }
+        },
+        {
+          title: lang.force_tfa,
+          data: 'attributes.force_tfa',
+          defaultContent: ''
         },
         {
           title: lang_edit.ratelimit,

--- a/data/web/lang/lang.en-gb.json
+++ b/data/web/lang/lang.en-gb.json
@@ -929,6 +929,7 @@
         "filters": "Filters",
         "fname": "Full name",
         "force_pw_update": "Force password update at next login",
+        "force_tfa": "TFA",
         "gal": "Global Address List",
         "goto_ham": "Learn as <b>ham</b>",
         "goto_spam": "Learn as <b>spam</b>",

--- a/data/web/templates/edit/mailbox-templates.twig
+++ b/data/web/templates/edit/mailbox-templates.twig
@@ -8,6 +8,7 @@
 
     <input type="hidden" value="default" name="sender_acl">
     <input type="hidden" value="0" name="force_pw_update">
+    <input type="hidden" value="0" name="force_tfa">
     <input type="hidden" value="0" name="sogo_access">
     <input type="hidden" value="0" name="protocol_access">
 
@@ -162,6 +163,14 @@
         <div class="form-check">
           <label><input type="checkbox" class="form-check-input" value="1" name="force_pw_update"{% if template.attributes.force_pw_update == '1' %} checked{% endif %}> {{ lang.edit.force_pw_update }}</label>
           <small class="text-muted">{{ lang.edit.force_pw_update_info|format(ui_texts.main_name) }}</small>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="offset-sm-2 col-sm-10">
+        <div class="form-check">
+          <label><input type="checkbox" class="form-check-input" value="1" name="force_tfa" id="force_tfa"{% if template.attributes.force_tfa == '1' %} checked{% endif %}> {{ lang.tfa.force_tfa }}</label>
+          <small class="text-muted">{{ lang.tfa.force_tfa_info }}</small>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?
Fixes force_tfa of mailbox templates being overwritten and not being available after creation

### Short Description

Adds a "TFA" column in the template overview table. Adds a checkbox for force_tfa in the template modification form. Fixes force_tfa being set to 0 on any modification

###  Affected Containers
- php-fpm-mailcow
- nginx-mailcow


## Did you run tests?
yes

### What did you tested?
tested manually that the functionality works
verified the results with
`docker compose exec -it mysql-mailcow bash -c "mysql -u mailcow -p\$MYSQL_PASSWORD mailcow -e \"select template, JSON_PRETTY(attributes) from templates where type='mailbox';\""`

### What were the final results? (Awaited, got)

TFA is displayed in the mailbox template overview table. force_tfa is loaded and stored correctly.