### PR TITLE
Refresh SOGo view after mailbox activation

### DIFF
--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -3505,7 +3505,6 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             // Track affected mailboxes for SOGo update
             $update_sogo_mailboxes[] = $username;
           }
-          return true;
         break;
         case 'mailbox_rename':
           $domain = $_data['domain'];


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Fixes SOGo access for mailboxes that are created inactive or with login disabled and later activated. The mailbox edit path now reaches the existing SOGo static-view refresh instead of returning before it can run.

Fixes #7136

### Affected Containers

- php-fpm-mailcow
- sogo-mailcow

## Did you run tests?

### What did you tested?

- PHP syntax check for the mailbox functions file
- diff whitespace check

### What were the final results? (Awaited, got)

Expected clean syntax/diff checks; got clean results.