### PR TITLE
Use absolute DNS targets in generated records

### DIFF
--- a/data/web/inc/ajax/dns_diagnostics.php
+++ b/data/web/inc/ajax/dns_diagnostics.php
@@ -1,6 +1,7 @@
 <?php
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/prerequisites.inc.php';
 require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/spf.inc.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . '/inc/functions.dns.inc.php';
 
 define('state_good', '<i class="bi bi-check-lg text-success"></i>');
 define('state_missing', '<i class="bi bi-x-lg text-danger"></i>');
@@ -430,13 +431,15 @@ if (isset($_SESSION['mailcow_cc_role']) && ($_SESSION['mailcow_cc_role'] == "adm
           }
           $state = implode('<br />', $state);
         }
+        $recommended_record = mailcow_dns_recommended_value($record[1], $record[2]);
+
         echo sprintf('
         <tr>
           <td>%s</td>
           <td>%s</td>
           <td class="dns-found">%s</td>
           <td class="dns-recommended">%s</td>
-        </tr>', $record[0], $record[1], $record[2], $state);
+        </tr>', $record[0], $record[1], $recommended_record, $state);
         $record[3] = explode('<br />', $state);
       }
 
@@ -446,7 +449,7 @@ if (isset($_SESSION['mailcow_cc_role']) && ($_SESSION['mailcow_cc_role'] == "adm
       foreach ($records as $record) {
         if ($domain == substr($record[0], -strlen($domain))) {
           $label = substr($record[0], 0, -strlen($domain)-1);
-          $val = $record[2];
+          $val = mailcow_dns_recommended_value($record[1], $record[2]);
 
           if (strlen($label) == 0) {
             $label = "@";
@@ -471,7 +474,7 @@ if (isset($_SESSION['mailcow_cc_role']) && ($_SESSION['mailcow_cc_role'] == "adm
           }
 
           foreach ($vals as $val) {
-            $dns_data .= str_replace($domain, $domain . '.', $val);
+            $dns_data .= $val;
           }
         }
       }

--- a/data/web/inc/functions.dns.inc.php
+++ b/data/web/inc/functions.dns.inc.php
@@ -1,0 +1,31 @@
+<?php
+
+function mailcow_dns_absolute_name($name) {
+  $name = trim($name);
+
+  if ($name === '' || $name === '.' || substr($name, -1) === '.') {
+    return $name;
+  }
+
+  return $name . '.';
+}
+
+function mailcow_dns_recommended_value($type, $value) {
+  $type = strtoupper($type);
+
+  if (in_array($type, array('CNAME', 'MX', 'PTR'), true)) {
+    return mailcow_dns_absolute_name($value);
+  }
+
+  if ($type == 'SRV') {
+    $parts = preg_split('/\s+/', trim($value));
+
+    if (!empty($parts[0])) {
+      $parts[0] = mailcow_dns_absolute_name($parts[0]);
+    }
+
+    return implode(' ', $parts);
+  }
+
+  return $value;
+}


### PR DESCRIPTION
## Contribution Guidelines
* [x] I've read the contribution guidelines and wholeheartedly agree them

## What does this PR include?
### Short Description
Generated DNS recommendations and downloaded zone files now render hostname targets as absolute names for MX, CNAME, PTR, and SRV records. This keeps values like `mail.example.net` from being interpreted relative to `$ORIGIN`.

Fixes #6984

### Affected Containers
- php-fpm-mailcow

## Did you run tests?
### What did you tested?
- PHP syntax checks for the DNS diagnostics files.
- Formatter smoke check for MX, CNAME, PTR, SRV, A, and TXT values.
- Staged diff whitespace check.

### What were the final results? (Awaited, got)
Expected clean syntax, formatter, and whitespace checks; got clean results.