### PR TITLE
Fixes #7287: /api/v1/add/time_limited_alias

### DIFF
--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -185,6 +185,7 @@ paths:
               example:
                 username: info@domain.tld
                 domain: domain.tld
+                description: my time limited alias
               properties:
                 username:
                   description: 'the mailbox an alias should be created for'
@@ -192,6 +193,18 @@ paths:
                 domain:
                   description: "the domain"
                   type: string
+                description:
+                  description: "a description for the alias"
+                  type: string
+                validity:
+                  description: "validity period in hours (1-87600); defaults to 8760 (1 year) if omitted"
+                  type: integer
+                permanent:
+                  description: "if true, the alias never expires"
+                  type: boolean
+              required:
+                - domain
+                - description
               type: object
       summary: Create time limited alias
   /api/v1/add/app-passwd:

--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -41,13 +41,15 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
           else {
             $username = $_SESSION['mailcow_cc_username'];
           }
-          if (isset($_data["validity"]) && !filter_var($_data["validity"], FILTER_VALIDATE_INT, array('options' => array('min_range' => 1, 'max_range' => 87600)))) {
-            $_SESSION['return'][] = array(
-              'type' => 'danger',
-              'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
-              'msg' => 'validity_missing'
-            );
-            return false;
+          if (isset($_data["validity"])) {
+            if (!filter_var($_data["validity"], FILTER_VALIDATE_INT, array('options' => array('min_range' => 1, 'max_range' => 87600)))) {
+              $_SESSION['return'][] = array(
+                'type' => 'danger',
+                'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
+                'msg' => 'validity_missing'
+              );
+              return false;
+            }
           }
           else {
             // Default to 1 yr
@@ -60,6 +62,14 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             $permanent = 0;
           }
           $domain = $_data['domain'];
+          if (!isset($_data['description']) || empty(trim($_data['description']))) {
+            $_SESSION['return'][] = array(
+              'type' => 'danger',
+              'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
+              'msg' => 'description_missing'
+            );
+            return false;
+          }
           $description = $_data['description'];
           $valid_domains[] = mailbox('get', 'mailbox_details', $username)['domain'];
           $valid_alias_domains = user_get_alias_details($username)['alias_domains'];
@@ -75,15 +85,25 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             return false;
           }
           $validity = strtotime("+" . $_data["validity"] . " hour");
-          $stmt = $pdo->prepare("INSERT INTO `spamalias` (`address`, `description`, `goto`, `validity`, `permanent`) VALUES
-            (:address, :description, :goto, :validity, :permanent)");
-          $stmt->execute(array(
-            ':address' => readable_random_string(rand(rand(3, 9), rand(3, 9))) . '.' . readable_random_string(rand(rand(3, 9), rand(3, 9))) . '@' . $domain,
-            ':description' => $description,
-            ':goto' => $username,
-            ':validity' => $validity,
-            ':permanent' => $permanent
-          ));
+          try {
+            $stmt = $pdo->prepare("INSERT INTO `spamalias` (`address`, `description`, `goto`, `validity`, `permanent`) VALUES
+              (:address, :description, :goto, :validity, :permanent)");
+            $stmt->execute(array(
+              ':address' => readable_random_string(rand(rand(3, 9), rand(3, 9))) . '.' . readable_random_string(rand(rand(3, 9), rand(3, 9))) . '@' . $domain,
+              ':description' => $description,
+              ':goto' => $username,
+              ':validity' => $validity,
+              ':permanent' => $permanent
+            ));
+          }
+          catch (PDOException $e) {
+            $_SESSION['return'][] = array(
+              'type' => 'danger',
+              'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),
+              'msg' => array('mysql_error', $e)
+            );
+            return false;
+          }
           $_SESSION['return'][] = array(
             'type' => 'success',
             'log' => array(__FUNCTION__, $_action, $_type, $_data_log, $_attr),

--- a/data/web/lang/lang.en-gb.json
+++ b/data/web/lang/lang.en-gb.json
@@ -435,6 +435,7 @@
         "defquota_empty": "Default quota per mailbox must not be 0.",
         "demo_mode_enabled": "Demo Mode is enabled",
         "description_invalid": "Resource description for %s is invalid",
+        "description_missing": "Please provide a description",
         "dkim_domain_or_sel_exists": "A DKIM key for \"%s\" exists and will not be overwritten",
         "dkim_domain_or_sel_invalid": "DKIM domain or selector invalid: %s",
         "domain_cannot_match_hostname": "Domain cannot match hostname",
@@ -556,7 +557,7 @@
         "unknown_tfa_method": "Unknown TFA method",
         "unlimited_quota_acl": "Unlimited quota prohibited by ACL",
         "username_invalid": "Username %s cannot be used",
-        "validity_missing": "Please assign a period of validity",
+        "validity_missing": "Please assign a period of validity between 1-87600",
         "value_missing": "Please provide all values",
         "version_invalid": "Version %s is invalid",
         "yotp_verification_failed": "Yubico OTP verification failed: %s"


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

Fixes for #7287:

- update OpenAPI spec to correctly reflect available and required fields
- properly throw an exception and HTTP error when required `description` field is not provided
- fix an issue where provided `validity` was always overridden by code

### Short Description

This PR fixes the bugs described in #7287 and an additional bug setting `validity` that was discovered while fixing that issue.

###  Affected Containers

- php-fpm-mailcow
- nginx-mailcow


## Did you run tests?

No automated/runtime tests — mailcow has no test harness covering this API path, and I don't have a live instance to exercise the endpoint against. I ran static validation only and reasoned through the runtime behavior from the code.

### What did you tested?

- `php -l` (PHP 8.2) on the modified `data/web/inc/functions.mailbox.inc.php` — syntax check.
- Schema/format validation of `data/web/api/openapi.yaml` (YAML parse) and `data/web/lang/lang.en-gb.json` (JSON parse).
- Manual code trace of the `/add/time_limited_alias` path: confirmed the original empty-200 came from the `NOT NULL` `description` insert throwing an uncaught `PDOException`, which the global `exception_handler` records to `$_SESSION['return']` but never echoes (PHP halts after the handler), and that the `validity` else branch overwrites valid client input.

### What were the final results? (Awaited, got)

- `php -l` → awaited: no syntax errors. got: No syntax errors detected.
- `openapi.yaml` / `lang.en-gb.json` → awaited: parse clean. got: both valid.
- Behavioral changes are not runtime-verified. By inspection they should yield: missing `description` → `danger/description_missing` instead of empty `200`; any other insert failure surfaced via mysql_error; a valid `validity` now preserved instead of forced to `8760`. Runtime confirmation would need a live mailcow testing instance, which I do not currently have.