### PR TITLE
Skip mta-sts certificate request when MTA-STS is not active for a domain

### DIFF
--- a/data/Dockerfiles/acme/acme.sh
+++ b/data/Dockerfiles/acme/acme.sh
@@ -255,6 +255,18 @@ while true; do
     for SUBDOMAIN in "${ADDITIONAL_WC_ARR[@]}"; do
       FULL_SUBDOMAIN="${SUBDOMAIN}.${SQL_DOMAIN}"
 
+      # Skip mta-sts subdomain unless MTA-STS is enabled (active) for this domain
+      if [[ "${SUBDOMAIN}" == "mta-sts" ]]; then
+        if [[ ${AUTODISCOVER_SAN} != "y" ]]; then
+          continue
+        fi
+        MTA_STS_ACTIVE=$(mariadb --skip-ssl --socket=/var/run/mysqld/mysqld.sock -u ${DBUSER} -p${DBPASS} ${DBNAME} -e "SELECT 1 FROM mta_sts WHERE domain = \"${SQL_DOMAIN}\" AND active = 1" -Bs)
+        if [[ -z "${MTA_STS_ACTIVE}" ]]; then
+          log_f "MTA-STS is not enabled for ${SQL_DOMAIN} - skipping mta-sts subdomain certificate"
+          continue
+        fi
+      fi
+
       # Skip if subdomain matches MAILCOW_HOSTNAME
       if [[ "${FULL_SUBDOMAIN}" == "${MAILCOW_HOSTNAME}" ]]; then
         continue

--- a/data/web/lang/lang.de-de.json
+++ b/data/web/lang/lang.de-de.json
@@ -728,6 +728,7 @@
         "mta_sts_mx": "MX-Server",
         "mta_sts_mx_info": "Erlaubt das Senden nur an explizit aufgeführte Mailserver-Hostnamen; der sendende MTA überprüft, ob der DNS-MX-Hostname mit der Richtlinienliste übereinstimmt, und erlaubt die Zustellung nur mit einem gültigen TLS-Zertifikat (schützt vor MITM).",
         "mta_sts_mx_notice": "Es können mehrere MX-Server angegeben werden (durch Kommas getrennt).",
+        "mta_sts_active_info": "Wenn nicht angehakt, wird die MTA-STS-Richtlinie nicht veröffentlicht und für die mta-sts-Subdomain kein Zertifikat über ACME angefordert.",
         "multiple_bookings": "Mehrfaches Buchen",
         "nexthop": "Next Hop",
         "none_inherit": "Keine Auswahl / Erben",

--- a/data/web/lang/lang.en-gb.json
+++ b/data/web/lang/lang.en-gb.json
@@ -728,6 +728,7 @@
         "mta_sts_mx": "MX server",
         "mta_sts_mx_info": "Allows sending only to explicitly listed mail server hostnames; the sending MTA checks if the DNS MX hostname matches the policy list, and only allows delivery with a valid TLS certificate (guards against MITM).",
         "mta_sts_mx_notice": "Multiple MX servers can be specified (separated by commas).",
+        "mta_sts_active_info": "If unchecked, the MTA-STS policy will not be published and no certificate will be requested for the mta-sts subdomain via ACME.",
         "multiple_bookings": "Multiple bookings",
         "none_inherit": "None / Inherit",
         "nexthop": "Next hop",

--- a/data/web/templates/edit/domain.twig
+++ b/data/web/templates/edit/domain.twig
@@ -340,7 +340,7 @@
                   <div class="row mb-4">
                     <div class="offset-sm-2 col-sm-10">
                       <div class="form-check">
-                        <label><input type="checkbox" class="form-check-input" value="1" name="active"{% if mta_sts.active == '1' %} checked{% endif %}> {{ lang.edit.active }}</label>
+                        <label><i style="font-size: 16px; cursor: pointer;" class="bi bi-patch-question-fill m-2 ms-0" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom" title="{{ lang.edit.mta_sts_active_info|raw }}"></i><input type="checkbox" class="form-check-input" value="1" name="active"{% if mta_sts.active == '1' %} checked{% endif %}> {{ lang.edit.active }}</label>
                       </div>
                     </div>
                   </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -465,7 +465,7 @@ services:
           condition: service_started
         unbound-mailcow:
           condition: service_healthy
-      image: ghcr.io/mailcow/acme:1.97
+      image: ghcr.io/mailcow/acme:1.98
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       environment:


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

When MTA-STS is not active for a domain (the "active" checkbox is unchecked, or no MTA-STS policy exists), the ACME container will no longer request a certificate for the `mta-sts.<domain>` subdomain.

Previously, `mta-sts` was added unconditionally to the additional SAN list for every active domain when `AUTODISCOVER_SAN=y`, so ACME tried to obtain a certificate for `mta-sts.<domain>` even when MTA-STS was never configured or explicitly disabled. This caused unnecessary certificate requests and log noise/failures for the `mta-sts` subdomain.

The ACME script now checks the `mta_sts` table for an active entry (`active = 1`) for the domain before adding the `mta-sts` subdomain, mirroring the logic already used for alias domains directly below it. A tooltip was added to the "active" checkbox in the domain MTA-STS settings to make this behaviour transparent to admins.

### Affected Containers

- acme-mailcow
- php-fpm-mailcow

## Did you run tests?

### What did you tested?

- Syntax check of the modified ACME script (`bash -n acme.sh`) and JSON validation of both changed language files.
- Behaviour with an active MTA-STS policy for a domain.
- Behaviour with MTA-STS inactive / not configured for a domain.

### What were the final results? (Awaited, got)

- With MTA-STS active: awaited a certificate request for `mta-sts.<domain>` as before - got exactly that.
- With MTA-STS inactive/not configured: awaited the subdomain to be skipped - got it skipped, with the log line `MTA-STS is not enabled for <domain> - skipping mta-sts subdomain certificate`.

Closes #6859
