### PR TITLE
Log SOGo webmail logins consistently as SSO in sasl_log

### DIFF
--- a/data/conf/dovecot/auth/mailcowauth.php
+++ b/data/conf/dovecot/auth/mailcowauth.php
@@ -74,7 +74,7 @@ if ($isSOGoRequest) {
   $sogo_sso_pass = file_get_contents("/etc/sogo-sso/sogo-sso.pass");
   if ($sogo_sso_pass === $post['password']){
     error_log('MAILCOWAUTH: SOGo SSO auth for user ' . $post['username']);
-    set_sasl_log($post['username'], $post['real_rip'], "SOGO");
+    set_sasl_log($post['username'], $post['real_rip'], "SSO");
     $result = true;
   }
 }


### PR DESCRIPTION
## Contribution Guidelines

* [x] Ive read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

SOGo webmail logins were recorded in `sasl_log` with the service value `SOGO`, while SOGos internal SSO authentication (`sogo-auth.php`) uses `SSO`. This caused inconsistent "last login" values for webmail users:

- The mailbox overview "Last mail login" column filters out `service = SSO` only, so `SOGO` entries were still counted there.
- The mailbox detail view only evaluates the `SSO` service for the last SSO login, so `SOGO` entries were ignored entirely.

This PR records SOGo webmail logins as `SSO` as well, so both SOGo authentication paths are handled consistently: they are excluded from the "last mail login" column and correctly surface as the last SSO login in the mailbox details.

### Affected Containers

- dovecot-mailcow

## Did you run tests?

### What did you tested?

- Logged in via SOGo webmail and verified the resulting `sasl_log` entry.
- Checked the "Last mail login" column in the mailbox overview and the last-login values in the mailbox detail view.

### What were the final results? (Awaited, got)

- Awaited: SOGo webmail login recorded as `SSO`, no longer shown as a misleading "last mail login", and reflected as the last SSO login in the mailbox details.
- Got: exactly that - the SOGo login is stored as `SSO` and handled consistently across both views.

Relates to #6853
