### PR TITLE
postfix: migrate from bookworm to trixie

### DIFF
--- a/data/Dockerfiles/postfix/Dockerfile
+++ b/data/Dockerfiles/postfix/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 LABEL maintainer="The Infrastructure Company GmbH <info@servercow.de>"
 

--- a/data/Dockerfiles/postfix/syslog-ng-redis_slave.conf
+++ b/data/Dockerfiles/postfix/syslog-ng-redis_slave.conf
@@ -1,4 +1,4 @@
-@version: 3.38
+@version: 4.8
 @include "scl.conf"
 options {
   chain_hostnames(off);
@@ -7,7 +7,7 @@ options {
   dns_cache(no);
   use_fqdn(no);
   owner("root"); group("adm"); perm(0640);
-  stats_freq(0);
+  stats(freq(0));
   bad_hostname("^gconfd$");
 };
 source s_src {

--- a/data/Dockerfiles/postfix/syslog-ng.conf
+++ b/data/Dockerfiles/postfix/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version: 3.38
+@version: 4.8
 @include "scl.conf"
 options {
   chain_hostnames(off);
@@ -7,7 +7,7 @@ options {
   dns_cache(no);
   use_fqdn(no);
   owner("root"); group("adm"); perm(0640);
-  stats_freq(0);
+  stats(freq(0));
   bad_hostname("^gconfd$");
 };
 source s_src {

--- a/data/conf/postfix/main.cf
+++ b/data/conf/postfix/main.cf
@@ -107,8 +107,6 @@ smtpd_sender_restrictions = reject_authenticated_sender_login_mismatch,
   reject_unknown_sender_domain
 smtpd_soft_error_limit = 3
 smtpd_tls_auth_only = yes
-smtpd_tls_dh1024_param_file = /etc/ssl/mail/dhparams.pem
-smtpd_tls_eecdh_grade = auto
 smtpd_tls_exclude_ciphers = ECDHE-RSA-RC4-SHA, RC4, aNULL, DES-CBC3-SHA, ECDHE-RSA-DES-CBC3-SHA, EDH-RSA-DES-CBC3-SHA
 smtpd_tls_loglevel = 1
 

--- a/data/conf/postfix/master.cf
+++ b/data/conf/postfix/master.cf
@@ -29,7 +29,6 @@ smtps    inet  n       -       n       -       -       smtpd
 # TLS protocol can be modified by setting submission_smtpd_tls_mandatory_protocols in extra.cf
 submission inet n       -       n       -       -       smtpd
   -o smtpd_client_restrictions=permit_mynetworks,permit_sasl_authenticated,reject
-  -o smtpd_enforce_tls=yes
   -o smtpd_tls_security_level=encrypt
   -o smtpd_tls_mandatory_protocols=$submission_smtpd_tls_mandatory_protocols
   -o tls_preempt_cipherlist=yes
@@ -38,7 +37,6 @@ submission inet n       -       n       -       -       smtpd
 10587      inet n       -       n       -       -       smtpd
   -o smtpd_upstream_proxy_protocol=haproxy
   -o smtpd_client_restrictions=permit_mynetworks,permit_sasl_authenticated,reject
-  -o smtpd_enforce_tls=yes
   -o smtpd_tls_security_level=encrypt
   -o smtpd_tls_mandatory_protocols=$submission_smtpd_tls_mandatory_protocols
   -o tls_preempt_cipherlist=yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -339,7 +339,7 @@ services:
             - dovecot
 
     postfix-mailcow:
-      image: ghcr.io/mailcow/postfix:3.7.11-2
+      image: ghcr.io/mailcow/postfix:3.10.12
       depends_on:
         mysql-mailcow:
           condition: service_started


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

This PR includes the upgrade of Postfix for mailcow while migrating from Bookworm runbase to trixie.

The change also includes some smaller deprecated config removals as well as the adaption of the new syslogng format.

The changed postfix settings were obsoleted and or already defined otherwise.

<!-- Please write a short description, what your PR does here. -->

###  Affected Containers

- postfix-mailcow

## Did you run tests?

### What did you tested?

Postfix startup, normal e-mailing. 

### What were the final results? (Awaited, got)

Just worked as expected.

Closes #7319