### PR TITLE
feat: distinguish login portals visually

### DIFF
--- a/data/web/css/build/014-mailcow.css
+++ b/data/web/css/build/014-mailcow.css
@@ -433,3 +433,24 @@ button[aria-expanded='true'] > .caret {
 .hr-title:not(:empty)::after {
   margin-left: 10px;
 }
+/* Visual differentiation of login portals */
+body.login-portal-user {
+  background-color: #f2faf5 !important;
+}
+body.login-portal-user .card {
+  border-top: 4px solid #198754 !important;
+}
+
+body.login-portal-domainadmin {
+  background-color: #f3f4fc !important;
+}
+body.login-portal-domainadmin .card {
+  border-top: 4px solid #0d6efd !important;
+}
+
+body.login-portal-admin {
+  background-color: #fdf3f3 !important;
+}
+body.login-portal-admin .card {
+  border-top: 4px solid #dc3545 !important;
+}

--- a/data/web/css/themes/mailcow-darkmode.css
+++ b/data/web/css/themes/mailcow-darkmode.css
@@ -455,3 +455,37 @@ input::placeholder {
 .btn-light, .btn-light:hover {
     background-image: none;
 }
+
+/* Dark Mode Login Portals */
+body.login-portal-user {
+  background-color: #121814 !important;
+}
+body.login-portal-user .card {
+  background-color: #1d2520 !important;
+  border-color: #27332c !important;
+}
+body.login-portal-user .card-header {
+  background-color: #121814 !important;
+}
+
+body.login-portal-domainadmin {
+  background-color: #13151c !important;
+}
+body.login-portal-domainadmin .card {
+  background-color: #1d202b !important;
+  border-color: #282c3c !important;
+}
+body.login-portal-domainadmin .card-header {
+  background-color: #13151c !important;
+}
+
+body.login-portal-admin {
+  background-color: #1a1111 !important;
+}
+body.login-portal-admin .card {
+  background-color: #281b1b !important;
+  border-color: #382525 !important;
+}
+body.login-portal-admin .card-header {
+  background-color: #1a1111 !important;
+}

--- a/data/web/templates/admin_index.twig
+++ b/data/web/templates/admin_index.twig
@@ -2,6 +2,8 @@
 
 {% block navbar %}{% endblock %}
 
+{% block body_class %}login-portal login-portal-admin{% endblock %}
+
 {% block content %}
 <div class="row mb-4" style="margin-top: 60px">
   <div class="col-12 col-md-7 col-lg-6 col-xl-5 ms-auto me-auto">
@@ -52,7 +54,7 @@
             </div>
           </div>
           <div class="d-flex justify-content-between mt-4" style="position: relative">
-            <button type="submit" class="btn btn-xs-lg btn-success w-100 mt-2 mx-auto" style="max-width: 400px;" value="Login">{{ lang.login.login }}</button>
+            <button type="submit" class="btn btn-xs-lg btn-danger w-100 mt-2 mx-auto" style="max-width: 400px;" value="Login">{{ lang.login.login }}</button>
           </div>
         </form>
         <div class="hr-title"><strong>{{ lang.login.other_logins }}</strong></div>
@@ -90,12 +92,17 @@
     </div>
 
     {% if custom_login.hide_user_quicklink != 1 or custom_login.hide_domainadmin_quicklink != 1 %}
-    <p class="text-center mt-3 text-muted" style="font-size: 0.9rem;">
-      {{ lang.login.login_linkstext }}<br>
-      {% if custom_login.hide_user_quicklink != 1 %}<a href="/">{{ lang.login.login_usertext }}</a>{% endif %}
-      {% if custom_login.hide_user_quicklink != 1 and custom_login.hide_domainadmin_quicklink != 1 %}|{% endif %}
-      {% if custom_login.hide_domainadmin_quicklink != 1 %}<a href="/domainadmin">{{ lang.login.login_domainadmintext }}</a>{% endif %}
-    </p>
+    <div class="text-center mt-4">
+      <div class="text-muted mb-2" style="font-size: 0.9rem;">{{ lang.login.login_linkstext }}</div>
+      <div class="d-flex justify-content-center gap-2 flex-wrap">
+        {% if custom_login.hide_user_quicklink != 1 %}
+          <a href="/" class="btn btn-sm btn-outline-success">{{ lang.login.login_usertext }}</a>
+        {% endif %}
+        {% if custom_login.hide_domainadmin_quicklink != 1 %}
+          <a href="/domainadmin" class="btn btn-sm btn-outline-primary">{{ lang.login.login_domainadmintext }}</a>
+        {% endif %}
+      </div>
+    </div>
     {% endif %}
   </div>
 </div>

--- a/data/web/templates/base.twig
+++ b/data/web/templates/base.twig
@@ -26,7 +26,7 @@
   <link rel="shortcut icon" href="/favicon.png" type="image/png">
   <link rel="icon" href="/favicon.png" type="image/png">
 </head>
-<body>
+<body class="{% block body_class %}{% endblock %}">
 <div class="overlay"></div>
 {% block navbar %}
 <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top p-0">

--- a/data/web/templates/domainadmin_index.twig
+++ b/data/web/templates/domainadmin_index.twig
@@ -2,6 +2,8 @@
 
 {% block navbar %}{% endblock %}
 
+{% block body_class %}login-portal login-portal-domainadmin{% endblock %}
+
 {% block content %}
 <div class="row mb-4" style="margin-top: 60px">
   <div class="col-12 col-md-7 col-lg-6 col-xl-5 ms-auto me-auto">
@@ -52,7 +54,7 @@
             </div>
           </div>
           <div class="d-flex justify-content-between mt-4" style="position: relative">
-            <button type="submit" class="btn btn-xs-lg btn-success w-100 mt-2 mx-auto" style="max-width: 400px;" value="Login">{{ lang.login.login }}</button>
+            <button type="submit" class="btn btn-xs-lg btn-primary w-100 mt-2 mx-auto" style="max-width: 400px;" value="Login">{{ lang.login.login }}</button>
           </div>
         </form>
         <div class="hr-title"><strong>{{ lang.login.other_logins }}</strong></div>
@@ -90,12 +92,17 @@
     </div>
 
     {% if custom_login.hide_user_quicklink != 1 or custom_login.hide_admin_quicklink != 1 %}
-    <p class="text-center mt-3 text-muted" style="font-size: 0.9rem;">
-      {{ lang.login.login_linkstext }}<br>
-      {% if custom_login.hide_user_quicklink != 1 %}<a href="/">{{ lang.login.login_usertext }}</a>{% endif %}
-      {% if custom_login.hide_user_quicklink != 1 and custom_login.hide_admin_quicklink != 1 %}|{% endif %}
-      {% if custom_login.hide_admin_quicklink != 1 %}<a href="/admin">{{ lang.login.login_admintext }}</a>{% endif %}
-    </p>
+    <div class="text-center mt-4">
+      <div class="text-muted mb-2" style="font-size: 0.9rem;">{{ lang.login.login_linkstext }}</div>
+      <div class="d-flex justify-content-center gap-2 flex-wrap">
+        {% if custom_login.hide_user_quicklink != 1 %}
+          <a href="/" class="btn btn-sm btn-outline-success">{{ lang.login.login_usertext }}</a>
+        {% endif %}
+        {% if custom_login.hide_admin_quicklink != 1 %}
+          <a href="/admin" class="btn btn-sm btn-outline-danger">{{ lang.login.login_admintext }}</a>
+        {% endif %}
+      </div>
+    </div>
     {% endif %}
   </div>
 </div>

--- a/data/web/templates/user_index.twig
+++ b/data/web/templates/user_index.twig
@@ -2,6 +2,8 @@
 
 {% block navbar %}{% endblock %}
 
+{% block body_class %}login-portal login-portal-user{% endblock %}
+
 {% block content %}
 <div class="row mb-4" style="margin-top: 60px">
   <div class="col-12 col-md-7 col-lg-6 col-xl-5 ms-auto me-auto">
@@ -108,12 +110,17 @@
     </div>
 
     {% if custom_login.hide_admin_quicklink != 1 or custom_login.hide_domainadmin_quicklink != 1 %}
-    <p class="text-center mt-3 text-muted" style="font-size: 0.9rem;">
-      {{ lang.login.login_linkstext }}<br>
-      {% if custom_login.hide_admin_quicklink != 1 %}<a href="/admin">{{ lang.login.login_admintext }}</a>{% endif %}
-      {% if custom_login.hide_admin_quicklink != 1 and custom_login.hide_domainadmin_quicklink != 1 %}|{% endif %}
-      {% if custom_login.hide_domainadmin_quicklink != 1 %}<a href="/domainadmin">{{ lang.login.login_domainadmintext }}</a>{% endif %}
-    </p>
+    <div class="text-center mt-4">
+      <div class="text-muted mb-2" style="font-size: 0.9rem;">{{ lang.login.login_linkstext }}</div>
+      <div class="d-flex justify-content-center gap-2 flex-wrap">
+        {% if custom_login.hide_domainadmin_quicklink != 1 %}
+          <a href="/domainadmin" class="btn btn-sm btn-outline-primary">{{ lang.login.login_domainadmintext }}</a>
+        {% endif %}
+        {% if custom_login.hide_admin_quicklink != 1 %}
+          <a href="/admin" class="btn btn-sm btn-outline-danger">{{ lang.login.login_admintext }}</a>
+        {% endif %}
+      </div>
+    </div>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

This PR addresses #7327 by making the user, domain administrator, and system administrator login portals more visually distinct.

Each login portal now has its own visual identity:
- Green for the user portal
- Blue for the domain administrator portal
- Red for the system administrator portal

The links under "Other logins" are also displayed as more prominent, color-coded buttons based on the destination portal.

Portal-specific styling is provided for both light and dark mode.

### Affected Containers

- php-fpm-mailcow
- nginx-mailcow

## Did you run tests?

### What did you tested?

Tested all three login portals on a local mailcow instance:

- User login portal
- Domain administrator login portal
- System administrator login portal
- Portal switching through the "Other logins" buttons
- Light mode
- Dark mode

### What were the final results? (Awaited, got)

Expected the three login portals to be visually distinguishable and the portal-switch links to be more prominent while preserving the existing navigation and visibility conditions.

The result matched the expected behavior. Each portal has a distinct visual identity, the "Other logins" actions are displayed as color-coded buttons, and navigation between the login portals works as expected in both light and dark mode.

### Screenshots

#### User portal

<img width="1920" height="1080" alt="User login portal with green visual identity" src="https://github.com/user-attachments/assets/a94b71be-b8f5-443b-af43-e0e80a4b8e2a" />

#### Domain administrator portal

<img width="1920" height="1080" alt="Domain administrator login portal with blue visual identity" src="https://github.com/user-attachments/assets/43759b0c-cdde-4d5d-8585-76d99f6ccf3f" />

#### System administrator portal

<img width="1920" height="1080" alt="System administrator login portal with red visual identity" src="https://github.com/user-attachments/assets/845ecf12-7f4d-4b37-946a-cc5dbd372734" />

Closes #7327