### PR TITLE
fix: cors allowed origins settings validation

### DIFF
--- a/data/web/api/openapi.yaml
+++ b/data/web/api/openapi.yaml
@@ -5856,7 +5856,7 @@ paths:
                 response:
                   value:
                     - type: "success"
-                      log: ["cors", "edit", {"allowed_origins": ["*", "mail.mailcow.tld"], "allowed_methods": ["POST", "GET", "DELETE", "PUT"]}]
+                      log: ["cors", "edit", {"allowed_origins": ["*", "https://mail.mailcow.tld"], "allowed_methods": ["POST", "GET", "DELETE", "PUT"]}]
                       msg: "cors_headers_edited"
           description: OK
           headers: { }
@@ -5873,7 +5873,7 @@ paths:
             schema:
               example:
                 attr:
-                  allowed_origins: ["*", "mail.mailcow.tld"]
+                  allowed_origins: ["*", "https://mail.mailcow.tld"]
                   allowed_methods: ["POST", "GET", "DELETE", "PUT"]
               properties:
                 attr:

--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -53,6 +53,28 @@ function valid_network($network) {
 function valid_hostname($hostname) {
   return filter_var($hostname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
 }
+// Validates a browser-style Origin: scheme://host[:port], no path/query/fragment/credentials
+function valid_origin($origin) {
+  $parts = parse_url($origin);
+  if ($parts === false || !isset($parts['scheme']) || !isset($parts['host'])) {
+    return false;
+  }
+  if (!in_array(strtolower($parts['scheme']), array('http', 'https'), true)) {
+    return false;
+  }
+  if (isset($parts['user']) || isset($parts['pass']) || isset($parts['path']) || isset($parts['query']) || isset($parts['fragment'])) {
+    return false;
+  }
+  $host = $parts['host'];
+  $host_without_brackets = trim($host, '[]');
+  if (!valid_hostname($host_without_brackets) && !filter_var($host_without_brackets, FILTER_VALIDATE_IP)) {
+    return false;
+  }
+  // Reject anything that doesn't round-trip to the exact same origin (e.g. stray trailing slash)
+  $port = isset($parts['port']) ? ':' . $parts['port'] : '';
+  $rebuilt = strtolower($parts['scheme']) . '://' . strtolower($host) . $port;
+  return strtolower($origin) === $rebuilt;
+}
 // Thanks to https://stackoverflow.com/a/49373789
 // Validates exact ip matches and ip-in-cidr, ipv4 and ipv6
 function ip_acl($ip, $networks) {
@@ -2283,10 +2305,13 @@ function cors($action, $data = null) {
         return false;
       }
 
-      $allowed_origins = isset($data['allowed_origins']) ? $data['allowed_origins'] : array($_SERVER['SERVER_NAME']);
+      $allowed_origins = isset($data['allowed_origins']) ? $data['allowed_origins'] : array(getBaseURL());
       $allowed_origins = !is_array($allowed_origins) ? array_filter(array_map('trim', explode("\n", $allowed_origins))) : $allowed_origins;
-      foreach ($allowed_origins as $origin) {
-        if (!filter_var($origin, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) && $origin != '*') {
+      foreach ($allowed_origins as &$origin) {
+        if ($origin === '*') {
+          continue;
+        }
+        if (!valid_origin($origin)) {
           $_SESSION['return'][] = array(
             'type' => 'danger',
             'log' => array(__FUNCTION__, $action, $data),
@@ -2294,7 +2319,10 @@ function cors($action, $data = null) {
           );
           return false;
         }
+        // browsers always send a lowercase scheme/host in the Origin header, so normalize to match
+        $origin = strtolower($origin);
       }
+      unset($origin);
 
       $allowed_methods = isset($data['allowed_methods']) ? $data['allowed_methods'] : array('GET', 'POST', 'PUT', 'DELETE');
       $allowed_methods  = !is_array($allowed_methods) ? array_map('trim', preg_split( "/( |,|;|\n)/", $allowed_methods)) : $allowed_methods;


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Fixes #7332. The CORS "Allowed Origins" setting (Configuration → Administrative Settings → CORS) validated each entry with `FILTER_VALIDATE_DOMAIN` / `FILTER_FLAG_HOSTNAME`, which only accepts bare hostnames (e.g. `example.com`). Per the Fetch/CORS spec, a browser's `Origin` header is always a full origin — `scheme://host[:port]` (e.g. `http://localhost:3000`) — never a bare hostname. Since the matching code in `cors('set_headers')` does an exact string comparison against `$_SERVER['HTTP_ORIGIN']`, a stored bare hostname could never match a real browser request, so the allowlist silently never worked for anything but the `*` wildcard.

### Details

This PR:
- Adds `valid_origin()` in `functions.inc.php`, which validates an entry is a well-formed origin: `http`/`https` scheme, a valid hostname or IP host (IPv6 bracket notation included), and no userinfo/path/query/fragment/trailing slash.
- Uses `valid_origin()` in `cors('edit')` instead of the bare-hostname check, so real origins like `http://localhost:3000` can now be saved.
- Normalizes accepted origins to lowercase before storing, since browsers always send a lowercase scheme/host in the `Origin` header (per the URL spec) — without this, an origin entered with any different casing would validate but then never match a real request.
- Updates the `edit`-path default (used when `allowed_origins` is omitted from the request, e.g. a partial API update) to build a full origin via the existing `getBaseURL()` helper instead of a bare hostname, so it still passes the stricter validation.
- Updates the `allowed_origins` example in `openapi.yaml` to a valid full origin.


###  Affected Containers

- php-fpm-mailcow
- nginx-mailcow


## Did you run tests?

Yes 

### What did you test?

Added a full origin (e.g. `http://localhost:3000`) to the CORS "Allowed Origins" setting, then called the mailcow API from a sample web app hosted on that origin.


### What were the final results? (Awaited, got)

Awaited: the setting saves successfully and the cross-origin API request succeeds. 
Got: success. the origin saved without error, and the request from the sample app succeeded.
