### PR TITLE
[Web] make CORS allowed origins accept and match real origins

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -2269,6 +2269,56 @@ function rspamd_ui($action, $data = null) {
     break;
   }
 }
+// Bring a configured origin into the form a browser sends in its Origin header,
+// scheme://host[:port]. Returns false if it cannot be one.
+// A bare hostname is legacy configuration from when only hostnames validated here,
+// it is read as https since that is the only scheme mailcow serves.
+function normalize_cors_origin($origin) {
+  $origin = trim($origin);
+  if ($origin === '') {
+    return false;
+  }
+  if ($origin === '*') {
+    return '*';
+  }
+  if (!preg_match('~^[a-z][a-z0-9+.-]*://~i', $origin)) {
+    $origin = 'https://' . $origin;
+  }
+
+  $parts = parse_url($origin);
+  if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
+    return false;
+  }
+  // an origin is only a scheme, a host and an optional port
+  if (isset($parts['query']) || isset($parts['fragment']) || isset($parts['user']) || isset($parts['pass'])) {
+    return false;
+  }
+  if (isset($parts['path']) && $parts['path'] !== '' && $parts['path'] !== '/') {
+    return false;
+  }
+
+  $scheme = strtolower($parts['scheme']);
+  if ($scheme !== 'http' && $scheme !== 'https') {
+    return false;
+  }
+
+  $host = strtolower($parts['host']);
+  // parse_url keeps the brackets of an IPv6 literal, they are not part of the address
+  $address = trim($host, '[]');
+  if (!filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) && !filter_var($address, FILTER_VALIDATE_IP)) {
+    return false;
+  }
+
+  $normalized = $scheme . '://' . $host;
+  if (isset($parts['port'])) {
+    if ($parts['port'] < 1 || $parts['port'] > 65535) {
+      return false;
+    }
+    $normalized .= ':' . $parts['port'];
+  }
+
+  return $normalized;
+}
 function cors($action, $data = null) {
   global $redis;
 
@@ -2283,10 +2333,11 @@ function cors($action, $data = null) {
         return false;
       }
 
-      $allowed_origins = isset($data['allowed_origins']) ? $data['allowed_origins'] : array($_SERVER['SERVER_NAME']);
+      $allowed_origins = isset($data['allowed_origins']) ? $data['allowed_origins'] : array('https://' . $_SERVER['SERVER_NAME']);
       $allowed_origins = !is_array($allowed_origins) ? array_filter(array_map('trim', explode("\n", $allowed_origins))) : $allowed_origins;
-      foreach ($allowed_origins as $origin) {
-        if (!filter_var($origin, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) && $origin != '*') {
+      foreach ($allowed_origins as $i => $origin) {
+        $normalized = normalize_cors_origin($origin);
+        if ($normalized === false) {
           $_SESSION['return'][] = array(
             'type' => 'danger',
             'log' => array(__FUNCTION__, $action, $data),
@@ -2294,6 +2345,8 @@ function cors($action, $data = null) {
           );
           return false;
         }
+        // store the origin as a browser will send it, so set_headers can match it
+        $allowed_origins[$i] = $normalized;
       }
 
       $allowed_methods = isset($data['allowed_methods']) ? $data['allowed_methods'] : array('GET', 'POST', 'PUT', 'DELETE');
@@ -2342,26 +2395,37 @@ function cors($action, $data = null) {
         );
       }
 
-      $cors_settings                    = !$cors_settings ? array('allowed_origins' => $_SERVER['SERVER_NAME'], 'allowed_methods' => 'GET, POST, PUT, DELETE') : $cors_settings;
-      $cors_settings['allowed_origins'] = empty($cors_settings['allowed_origins']) ? $_SERVER['SERVER_NAME'] : $cors_settings['allowed_origins'];
+      $cors_settings                    = !$cors_settings ? array('allowed_origins' => 'https://' . $_SERVER['SERVER_NAME'], 'allowed_methods' => 'GET, POST, PUT, DELETE') : $cors_settings;
+      $cors_settings['allowed_origins'] = empty($cors_settings['allowed_origins']) ? 'https://' . $_SERVER['SERVER_NAME'] : $cors_settings['allowed_origins'];
       $cors_settings['allowed_methods'] = empty($cors_settings['allowed_methods']) ? 'GET, POST, PUT, DELETE, OPTION' : $cors_settings['allowed_methods'];
 
       return $cors_settings;
     break;
     case "set_headers":
       $cors_settings = cors('get');
-      // check if requested origin is in allowed origins
-      $allowed_origins = explode(', ', $cors_settings['allowed_origins']);
-      $cors_settings['allowed_origins'] = $allowed_origins[0];
-      if (in_array('*', $allowed_origins)){
-        $cors_settings['allowed_origins'] = '*';
-      } else if (array_key_exists('HTTP_ORIGIN', $_SERVER) && in_array($_SERVER['HTTP_ORIGIN'], $allowed_origins)) {
-        $cors_settings['allowed_origins'] = $_SERVER['HTTP_ORIGIN'];
+      // normalize the stored list, it may still hold bare hostnames written before
+      // origins were validated as origins
+      $allowed_origins = array_filter(array_map('normalize_cors_origin', explode(',', $cors_settings['allowed_origins'])));
+      $origin = isset($_SERVER['HTTP_ORIGIN']) ? normalize_cors_origin($_SERVER['HTTP_ORIGIN']) : false;
+
+      $allow_origin = null;
+      if (in_array('*', $allowed_origins, true)) {
+        $allow_origin = '*';
+      } else if ($origin !== false && in_array($origin, $allowed_origins, true)) {
+        $allow_origin = $origin;
       }
       // always allow OPTIONS for preflight request
       $cors_settings["allowed_methods"] = empty($cors_settings["allowed_methods"]) ? 'OPTIONS' : $cors_settings["allowed_methods"] . ', ' . 'OPTIONS';
 
-      header('Access-Control-Allow-Origin: ' . $cors_settings['allowed_origins']);
+      // an origin that is not allowed gets no Access-Control-Allow-Origin at all,
+      // sending an origin that is not the requesting one tells a browser nothing
+      if ($allow_origin !== null) {
+        header('Access-Control-Allow-Origin: ' . $allow_origin);
+      }
+      if ($allow_origin !== '*') {
+        // the response depends on the request origin, keep caches from mixing them up
+        header('Vary: Origin', false);
+      }
       header('Access-Control-Allow-Methods: '. $cors_settings['allowed_methods']);
       header('Access-Control-Allow-Headers: Accept, Content-Type, X-Api-Key, Origin');
 


### PR DESCRIPTION
## What

The CORS "Allowed Origins" list cannot allow any origin. It validates entries as
bare hostnames, but matches them against a header that is never a bare hostname.

**Saving.** `cors()` `case "edit"` validated each entry with
`FILTER_VALIDATE_DOMAIN` / `FILTER_FLAG_HOSTNAME`, which accepts `example.com` and
rejects anything carrying a scheme or a port. A real origin could not be saved at
all — it failed with `cors_invalid_origin`.

**Matching.** `set_headers` then compared that hostname list against
`$_SERVER['HTTP_ORIGIN']`, which per Fetch is always `scheme://host[:port]`. The
`in_array` could never match, so the code fell through to reflecting
`$allowed_origins[0]` — the first configured entry — regardless of who was asking.

Net effect: the allowlist only ever worked via the `*` wildcard, which defeats the
point of an allowlist.

## Fix

Validate and store origins in the form a browser actually sends, and match on that.
One shared `normalize_cors_origin()` is used by both the save path and the match
path, so the two can't drift apart again.

A bare hostname is still accepted and read as `https://<host>`. That is deliberate:
it is what the shipped default has always been (`$_SERVER['SERVER_NAME']`), and the
settings form is pre-filled with it — so rejecting it would mean an admin who opens
the CORS page and clicks Save gets an error on a value they never chose, and every
existing install would have to re-enter its origins by hand. https is the only
scheme mailcow serves, so the inference is safe. The defaults now carry the scheme
too.

An origin that is *not* allowed now gets **no** `Access-Control-Allow-Origin` header
at all. Reflecting some other configured origin told the browser nothing and only
obscured the mismatch (this is what produced the confusing error in the issue's
screenshot). `Vary: Origin` is sent when the header depends on the request origin.

## Verification

`php -l` clean. Exercised the real functions from the patched file.

Saving — what an admin can actually store:

| admin types | before | after |
|---|---|---|
| `http://localhost:3000` | **rejected** | `http://localhost:3000` |
| `https://app.example.com` | **rejected** | `https://app.example.com` |
| `https://a.com:8443` | **rejected** | `https://a.com:8443` |
| `mail.example.org` | `mail.example.org` | `https://mail.example.org` |
| `*` | `*` | `*` |

Matching — header emitted for a given `Origin`:

| stored | Origin | before | after |
|---|---|---|---|
| `http://localhost:3000` | `http://localhost:3000` | *unreachable, cannot be saved* | reflected |
| `mail.example.org` (legacy) | `https://mail.example.org` | `ACAO: mail.example.org` (never matches) | reflected |
| `https://a.com, https://b.com` | `https://b.com` | *unreachable* | reflected |
| `https://a.com, https://b.com` | `https://evil.com` | `ACAO: https://a.com` | **no header** |
| `https://a.com:8443` | `https://a.com:9000` | *unreachable* | **no header** (port is part of the origin) |
| `*` | anything | `*` | `*` |
| `https://a.com` | *(none sent)* | `ACAO: https://a.com` | **no header** |

Normalizer accepts `http`/`https` with optional port, IPv4 and IPv6 literals, `*`,
lowercases the host, tolerates a trailing slash; rejects paths, query strings,
fragments, embedded credentials, non-http(s) schemes (`ftp:`, `javascript:`,
`file:`), empty input and out-of-range ports.

Refs #7332
