### PR TITLE
[Web] return sender_acl in get/mailbox API

### DIFF
--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -5320,6 +5320,14 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               $mailboxdata['rl_scope'] = 'domain';
             }
             $mailboxdata['is_relayed'] = $row['backupmx'];
+            // Internal send-as ACL for this mailbox, mirrors the sender_acl field accepted by edit/mailbox
+            $mailboxdata['sender_acl'] = array();
+            $stmt = $pdo->prepare("SELECT `send_as` FROM `sender_acl` WHERE `logged_in_as` = :username AND `external` = '0'");
+            $stmt->execute(array(':username' => $_data));
+            $sender_acl_rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            foreach ($sender_acl_rows as $sender_acl_row) {
+              $mailboxdata['sender_acl'][] = $sender_acl_row['send_as'];
+            }
           }
           $stmt = $pdo->prepare("SELECT `tag_name`
             FROM `tags_mailbox` WHERE `username`= :username");


### PR DESCRIPTION
## What

`sender_acl` can be **set** via `POST /api/v1/edit/mailbox`, but it was never
**returned** by `GET /api/v1/get/mailbox/{mailbox}` or `.../get/mailbox/all`. An API
client therefore can't read back what it wrote, and can't see a mailbox's send-as
permissions at all.

## Fix

Add the mailbox's internal send-as ACL to `mailbox_details` as `sender_acl` — an
array of `send_as` values from the `sender_acl` table (`external = 0`), mirroring the
field `edit/mailbox` accepts, so a get→edit round-trip is symmetric.

It's added in the same detailed-fields block as `rl`/quota info, so the deliberately
lightweight `get/mailbox/reduced` endpoint is unaffected.

## Verification (live stack)

```
# before setting anything
GET /api/v1/get/mailbox/alicetest@example-test.com
  -> sender_acl: []                      (key now present, empty)

# set it
POST /api/v1/edit/mailbox  {"attr":{"sender_acl":["*"]},"items":[...]}  -> success

# read back
GET /api/v1/get/mailbox/alicetest@example-test.com   -> sender_acl: ["*"]
GET /api/v1/get/mailbox/all                           -> sender_acl: ["*"]
GET /api/v1/get/mailbox/reduced                       -> (no sender_acl — stays light)
```

Round-trip confirmed; `reduced` unchanged; `php -l` clean.

Fixes #7011
