### PR TITLE
[Unbound] set do-ip6 from ENABLE_IPV6

### DIFF
--- a/data/Dockerfiles/unbound/docker-entrypoint.sh
+++ b/data/Dockerfiles/unbound/docker-entrypoint.sh
@@ -9,6 +9,17 @@ echo "Receiving root hints..."
 curl -#o /etc/unbound/root.hints https://www.internic.net/domain/named.cache
 /usr/sbin/unbound-control-setup
 
+# Follow ENABLE_IPV6: when IPv6 is disabled the container has no IPv6 route, and
+# unbound with do-ip6: yes keeps selecting IPv6 targets, fails, and gives up instead
+# of falling back to IPv4 (SERVFAIL -> unhealthy). Override do-ip6 accordingly.
+mkdir -p /etc/unbound/conf.d
+if [ "${ENABLE_IPV6}" = "false" ]; then
+  echo "ENABLE_IPV6 is false, setting do-ip6: no for unbound"
+  printf 'server:\n  do-ip6: no\n' > /etc/unbound/conf.d/ipv6.conf
+else
+  rm -f /etc/unbound/conf.d/ipv6.conf
+fi
+
 # Run hooks
 for file in /hooks/*; do
   if [ -x "${file}" ]; then

--- a/data/conf/unbound/unbound.conf
+++ b/data/conf/unbound/unbound.conf
@@ -35,6 +35,10 @@ server:
   unwanted-reply-threshold: 10000
   ipsecmod-enabled: no
 
+# Runtime overrides written by the entrypoint (e.g. do-ip6 based on ENABLE_IPV6).
+# A later include overrides earlier server: options; an empty conf.d is fine.
+include: "/etc/unbound/conf.d/*.conf"
+
 remote-control:
   control-enable: yes
   control-interface: 127.0.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       environment:
         - TZ=${TZ}
         - SKIP_UNBOUND_HEALTHCHECK=${SKIP_UNBOUND_HEALTHCHECK:-n}
+        - ENABLE_IPV6=${ENABLE_IPV6:-true}
       volumes:
         - ./data/hooks/unbound:/hooks:Z
         - ./data/conf/unbound/unbound.conf:/etc/unbound/unbound.conf:ro,Z


### PR DESCRIPTION
## What

unbound's `do-ip6` was hardcoded to `yes` with nothing tying it to `ENABLE_IPV6`
(the unbound container wasn't even passed the variable). With `ENABLE_IPV6=false`
the mailcow network is IPv4-only, so the container has no IPv6 — but unbound still
selects IPv6 targets, fails instantly (`network unreachable`), and **gives up
instead of falling back to IPv4**, returning SERVFAIL. Its healthcheck then marks it
unhealthy, and because nginx/postfix/rspamd `depends_on` it `service_healthy`, the
whole stack fails to start.

Full diagnosis in #7350 (measured: ~30ms SERVFAIL, not DNSSEC, not the network).

## Fix

Make `do-ip6` follow `ENABLE_IPV6`:

1. `docker-compose.yml` — pass `ENABLE_IPV6` to the `unbound-mailcow` service (as
   `nginx-mailcow` already receives it).
2. `data/conf/unbound/unbound.conf` — `include: "/etc/unbound/conf.d/*.conf"` (keeps
   `do-ip6: yes` as the default).
3. `docker-entrypoint.sh` — write `conf.d/ipv6.conf` with `do-ip6: no` only when
   `ENABLE_IPV6=false`; otherwise remove it (empty conf.d → default `yes`).

Deterministic, uses the existing `ENABLE_IPV6` knob, default (IPv6-enabled) behavior
unchanged.

## Verification (live, full stack)

- **`ENABLE_IPV6=false`, full `docker compose up -d`:** entrypoint writes the
  override, `unbound-checkconf -o do-ip6` → `no`, recursion `@127.0.0.1` → `NOERROR`,
  **unbound becomes healthy, and all services start** — including nginx, postfix,
  rspamd and dovecot, which previously never started (`dependency ... is unhealthy`).
- **`ENABLE_IPV6=true` and unset:** entrypoint writes no override, effective
  `do-ip6` stays `yes` — default unchanged.
- `unbound-checkconf` confirms a later `include` overrides the earlier `do-ip6` and
  an empty `conf.d` is tolerated (no error). Entrypoint passes `bash -n` + shellcheck.

Fixes #7350
Refs #7296
