### PR TITLE
Fix nginx CVE-2026-42533

### DIFF
--- a/data/Dockerfiles/nginx/Dockerfile
+++ b/data/Dockerfiles/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.30.3-alpine
+FROM nginx:1.30.4-alpine
 LABEL maintainer "The Infrastructure Company GmbH <info@servercow.de>"
 
 ENV PIP_BREAK_SYSTEM_PACKAGES=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -419,7 +419,7 @@ services:
         - php-fpm-mailcow
         - sogo-mailcow
         - rspamd-mailcow
-      image: ghcr.io/mailcow/nginx:1.30.3-1
+      image: ghcr.io/mailcow/nginx:1.30.4
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       environment:


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

nginx version bump to 1.30.4

### Short Description

Fix CVE-2026-42533 in nginx image.

###  Affected Containers

- nginx

## Did you run tests?

### What did you tested?

check if nginx container starts with correct version

### What were the final results? (Awaited, got)

awaited nginx version 1.30.4, got version 1.30.4