### PR TITLE
implement response helpers for alert and exit with error api

### DIFF
--- a/data/web/inc/response_helpers.inc.php
+++ b/data/web/inc/response_helpers.inc.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * ALERT_SESSION_KEY is not meant to be changed somewhere else.
+ * If you have a good reason to change it, then change it here.
+ */
+define('ALERT_SESSION_KEY', 'return');
+
+
+/**
+ * Returns a JSON error and terminates the request.
+ * 
+ * @param string $message Error message to display.
+ * @param string $type type of the response (e.g., error).
+ * @param int $status_code The HTTP status code.
+ * @param bool $should_exit Terminates the request, if true.
+ */
+function exit_with_api_error(string $message, string $type = 'error', int $status_code = 400, bool $should_exit = true): void
+{
+    http_response_code($status_code);
+
+    echo json_encode(array(
+        'type' => $type,
+        'msg'  => $message
+    ));
+
+    if ($should_exit === true) {
+        exit();
+    }
+}
+
+/**
+ * Clears the session key named `ALERT_SESSION_KEY`.
+ * 
+ * Session with key named `ALERT_SESSION_KEY` is used to flash messages
+ * to the UI. We need to clear it at the very end of the request, therefore,
+ * when user refreshes the browser, won't show the same flash again.
+ */
+function clear_session_alerts(): void
+{
+    if (isset($_SESSION[ALERT_SESSION_KEY])) {
+        unset($_SESSION[ALERT_SESSION_KEY]);
+    }
+}
+
+/**
+ * Appends a flash message to the session named `ALERT_SESSION_KEY`.
+ * 
+ * @param string $type The alert type of bootstrap css library (e.g., 'danger', 'success', 'warning').
+ * @param string $message The alert message to display in UI.
+ */
+function add_session_alert(string $type, string $message): void
+{
+    $_SESSION[ALERT_SESSION_KEY][] = [
+        'type' => $type,
+        'msg'  => $message
+    ];
+}

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -2055,9 +2055,6 @@ if (isset($_GET['query'])) {
         case "identity-provider-test":
           process_edit_return(identity_provider('test', $attr));
         break;
-        case "cors":
-          process_edit_return(cors('edit', $attr));
-        break;
         case "reset-password-notification":
           process_edit_return(reset_password('edit_notification', $attr));
         break;

--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -2081,8 +2081,7 @@ if (isset($_GET['query'])) {
       exit();
   }
 }
-if (array_key_exists('mailcow_cc_api', $_SESSION) && $_SESSION['mailcow_cc_api'] === true) {
-  if (isset($_SESSION['mailcow_cc_api']) && $_SESSION['mailcow_cc_api'] === true) {
-    unset($_SESSION['return']);
-  }
+
+if (isset($_SESSION['mailcow_cc_api']) && $_SESSION['mailcow_cc_api'] === true) {
+  unset($_SESSION['return']);
 }


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

Response helper functions for:

- exit with API error
- append to flash messages
- clear the flashed messages

### Short Description

###  Affected Containers

- php-fpm-mailcow

## Did you run tests?

Yes, tested the UI and some actions. All works as expected. But, it needs more testing.

### What did you tested?

This PR requires intensive testing due to the breaking change I've made to error responses.