### PR TITLE
Remove WL_FWD_HOST duplicate

### DIFF
--- a/data/conf/rspamd/local.d/composites.conf
+++ b/data/conf/rspamd/local.d/composites.conf
@@ -66,9 +66,6 @@ FUZZY_HAM_MISMATCH {
 FUZZY_SPAM_MISMATCH {
   expression = "( -LOCAL_FUZZY_WHITE ) & ( ^BAYES_SPAM | ^NEURAL_SPAM_LONG | ^NEURAL_SPAM_SHORT )";
 }
-WL_FWD_HOST {
-  expression = "-WHITELISTED_FWD_HOST & (^g+:rbl | ^g+:policies | ^g+:hfilter | ^g:neural)";
-}
 ENCRYPTED_CHAT {
   expression = "CHAT_VERSION_HEADER & ENCRYPTED_PGP";
 }


### PR DESCRIPTION
## Contribution Guidelines

* [X] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

`WL_FWD_HOST` is defined twice in `data/conf/rspamd/local.d/composites.conf` with identical expressions (lines 50-52 and 69-71). This removes the second, redundant definition. No functional change.

###  Affected Containers

- rspamd-mailcow

## Did you run tests?

### What did you tested?

Restarted rspamd-mailcow with the duplicate removed and checked the container logs for config parse errors.

### What were the final results? (Awaited, got)

Expected: rspamd starts cleanly and WL_FWD_HOST remains defined with an unchanged expression. Got exactly that.