### PR TITLE
fix: restore subject display in quarantine overview

### DIFF
--- a/data/conf/rspamd/meta_exporter/pipe.php
+++ b/data/conf/rspamd/meta_exporter/pipe.php
@@ -53,7 +53,7 @@ $raw_data = mb_convert_encoding($raw_data_content, 'HTML-ENTITIES', "UTF-8");
 $raw_size = (int)$_FILES['message']['size'];
 
 $qid      = $meta['qid']     ?? 'unknown';
-$subject  = iconv_mime_decode($meta['subject'] ?? '');
+$subject  = $meta['subject'] ?? '';
 $score    = $meta['score']   ?? 0;
 $rcpts    = $meta['rcpt']    ?? array();
 $user     = $meta['user']    ?? 'unknown';

--- a/data/conf/rspamd/meta_exporter/pushover.php
+++ b/data/conf/rspamd/meta_exporter/pushover.php
@@ -50,7 +50,7 @@ $qid      = $meta['qid']    ?? 'unknown';
 $rcpts    = $meta['rcpt']   ?? array();
 $sender   = $meta['from']   ?? '';
 $ip       = $meta['ip']     ?? 'unknown';
-$subject  = iconv_mime_decode($meta['subject'] ?? '');
+$subject  = $meta['subject'] ?? '';
 $messageid= $meta['message_id'] ?? '';
 $priority = 0;
 


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Fixes #7356.

Since moving to rspamd's multipart metadata_exporter with 2026-07, subject is a JSON encoded UTF-8 string and no longer a MIME encoded ASCII string. 
While `iconv_mime_decode` returns the unchanged string for plain ASCII subjects, it errors out returning `false` If the quarantined email has UTF-8 glyphs (diacritics, emoji, ...) in its subject. This causes an empty subject to be stored in the quarantine database table.
This PR simply removes the now obsolete `iconv_mime_decode` in the quarantine processor (`pipe.php`). The same code path in `pushover.php`was also fixed.

###  Affected Containers

- rspamd-mailcow

## Did you run tests?

Developed and tested on a staging mailcow stack and already deployed to production.

### What did you test?

Whether the subject of quarantined emails is correctly shown in the quarantine overview (both for users and admins).

### What were the final results? (Awaited, got)

After 2026-07 update before fix: empty subjects in quarantine overview
Awaited: subject correctly displayed in quarantine overview
Got: subject correctly displayed in quarantine overview
<img width="1132" height="811" alt="quarantine" src="https://github.com/user-attachments/assets/97492160-65fa-429d-b86f-c3320a577596" />
