### PR TITLE
[Web] update modified timestamp when tags change

### DIFF
--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -2837,6 +2837,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                 ':domain' => $domain
               ));
               // save tags
+              $tags_changed = false;
               foreach($tags as $index => $tag){
                 if (empty($tag)) continue;
                 if ($index > $GLOBALS['TAGGING_LIMIT']) {
@@ -2852,6 +2853,13 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                   ':domain' => $domain,
                   ':tag_name' => $tag,
                 ));
+                if ($stmt->rowCount() > 0) $tags_changed = true;
+              }
+              // tags are stored in a separate table, so adding one does not touch
+              // `domain` and its `modified` ON UPDATE column never fires
+              if ($tags_changed) {
+                $stmt = $pdo->prepare("UPDATE `domain` SET `modified` = NOW() WHERE `domain` = :domain");
+                $stmt->execute(array(':domain' => $domain));
               }
 
               $_SESSION['return'][] = array(
@@ -3005,6 +3013,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                 ':domain' => $domain
               ));
               // save tags
+              $tags_changed = false;
               foreach($tags as $index => $tag){
                 if (empty($tag)) continue;
                 if ($index > $GLOBALS['TAGGING_LIMIT']) {
@@ -3020,6 +3029,13 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                   ':domain' => $domain,
                   ':tag_name' => $tag,
                 ));
+                if ($stmt->rowCount() > 0) $tags_changed = true;
+              }
+              // tags are stored in a separate table, so adding one does not touch
+              // `domain` and its `modified` ON UPDATE column never fires
+              if ($tags_changed) {
+                $stmt = $pdo->prepare("UPDATE `domain` SET `modified` = NOW() WHERE `domain` = :domain");
+                $stmt->execute(array(':domain' => $domain));
               }
 
               $_SESSION['return'][] = array(
@@ -3479,6 +3495,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               ));
             }
             // save tags
+            $tags_changed = false;
             foreach($tags as $index => $tag){
               if (empty($tag)) continue;
               if ($index > $GLOBALS['TAGGING_LIMIT']) {
@@ -3495,8 +3512,15 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                   ':username' => $username,
                   ':tag_name' => $tag,
                 ));
+                if ($stmt->rowCount() > 0) $tags_changed = true;
               } catch (Exception $e) {
               }
+            }
+            // tags are stored in a separate table, so adding one does not touch
+            // `mailbox` and its `modified` ON UPDATE column never fires
+            if ($tags_changed) {
+              $stmt = $pdo->prepare("UPDATE `mailbox` SET `modified` = NOW() WHERE `username` = :username");
+              $stmt->execute(array(':username' => $username));
             }
 
             $_SESSION['return'][] = array(
@@ -6273,6 +6297,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               return false;
             }
 
+            $tags_changed = false;
             foreach($tags as $tag){
               // delete tag
               $wasModified = true;
@@ -6281,6 +6306,13 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                 ':domain' => $domain,
                 ':tag_name' => $tag,
               ));
+              if ($stmt->rowCount() > 0) $tags_changed = true;
+            }
+            // tags are stored in a separate table, so removing one does not touch
+            // `domain` and its `modified` ON UPDATE column never fires
+            if ($tags_changed) {
+              $stmt = $pdo->prepare("UPDATE `domain` SET `modified` = NOW() WHERE `domain` = :domain");
+              $stmt->execute(array(':domain' => $domain));
             }
           }
 
@@ -6325,6 +6357,7 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
             }
 
             // delete tags
+            $tags_changed = false;
             foreach($tags as $tag){
               $wasModified = true;
 
@@ -6333,6 +6366,13 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                 ':username' => $username,
                 ':tag_name' => $tag,
               ));
+              if ($stmt->rowCount() > 0) $tags_changed = true;
+            }
+            // tags are stored in a separate table, so removing one does not touch
+            // `mailbox` and its `modified` ON UPDATE column never fires
+            if ($tags_changed) {
+              $stmt = $pdo->prepare("UPDATE `mailbox` SET `modified` = NOW() WHERE `username` = :username");
+              $stmt->execute(array(':username' => $username));
             }
           }
 


### PR DESCRIPTION
## Description

Adding or removing a tag on a domain or mailbox never updated the `Last modified` timestamp shown in the UI.

Tags live in the separate `tags_domain` / `tags_mailbox` tables, so a tag change never writes to the `domain` / `mailbox` row itself. Since `modified` is declared `DATETIME ON UPDATE CURRENT_TIMESTAMP`, it only advances when that row is actually written.

On the domain edit path the surrounding statement only writes `description` and `gal`:

```sql
UPDATE `domain` SET `description` = :description, `gal` = :gal WHERE `domain` = :domain
```

When only a tag changed, those values are identical to what is already stored, so MariaDB skips the row write entirely and the ON UPDATE clause never fires. The same applies to mailbox tags and to both tag *deletion* paths.

This bumps `modified` explicitly whenever a tag row was actually inserted or deleted. The `rowCount()` check keeps it precise: re-saving a tag that already exists, or deleting one that is not there, still leaves the timestamp untouched.

Covers all five paths: domain edit (domain-admin and admin branches), mailbox edit, and the `delete/domain/tag` + `delete/mailbox/tag` endpoints.

## Verification

On a live stack, reading `modified` straight from MariaDB:

| action | before | after |
|---|---|---|
| add domain tag | unchanged (`14:05:10` stayed `14:05:10`) | **bumped** |
| add mailbox tag | unchanged | **bumped** |
| delete domain tag | unchanged | **bumped** (`14:05:10` → `14:06:14`) |
| delete mailbox tag | unchanged | **bumped** (`14:05:14` → `14:06:19`) |
| delete a tag that does not exist | unchanged | unchanged (no false bump) |

A normal description edit still bumps the timestamp exactly as before.

Fixes #6931