### PR TITLE
[Dovecot] recover from stale imapsync lock files

### DIFF
--- a/data/Dockerfiles/dovecot/imapsync_runner.pl
+++ b/data/Dockerfiles/dovecot/imapsync_runner.pl
@@ -38,7 +38,7 @@ sub qqw($) {
 $run_dir="/tmp";
 $dsn = 'DBI:mysql:database=' . $ENV{'DBNAME'} . ';mysql_socket=/var/run/mysqld/mysqld.sock';
 $lock_file = $run_dir . "/imapsync_busy";
-$lockmgr = LockFile::Simple->make(-autoclean => 1, -max => 1);
+$lockmgr = LockFile::Simple->make(-autoclean => 1, -max => 1, -stale => 1);
 $lockmgr->lock($lock_file) || die "can't lock ${lock_file}";
 $dbh = DBI->connect($dsn, $ENV{'DBUSER'}, $ENV{'DBPASS'}, {
   mysql_auto_reconnect => 1,


### PR DESCRIPTION
## Description

A sync job can get stuck on "pending" forever, with the `dovecot_imapsync_runner` cron silently failing every minute.

`imapsync_runner.pl` guards itself with `LockFile::Simple`:

```perl
$lockmgr = LockFile::Simple->make(-autoclean => 1, -max => 1);
$lockmgr->lock($lock_file) || die "can't lock ${lock_file}";
```

`LockFile::Simple` only checks whether the lock file *exists*. `-autoclean` removes locks held by the current process at exit, but if the process dies without unlocking — container restart, OOM kill, SIGKILL — `/tmp/imapsync_busy.lock` stays on disk forever.

From then on every run started by ofelia dies at line 42 with:

```
can't lock /tmp/imapsync_busy at /usr/local/bin/imapsync_runner.pl line 42.
```

That `die` happens *before* the try/catch around the actual `IPC::Run::run(...)`, so the `imapsync` row is never updated. It keeps the stale values from the run that created the orphaned lock (`is_running = 1`, `last_run = NULL`, `returned_text = 'Could not start or finish imapsync'`), which the UI renders as a job permanently stuck on "pending".

Enabling `-stale` makes `LockFile::Simple` compare the PID recorded in the lock file against the running processes and break the lock only when that process is gone.

## Verification

Tested inside `dovecot-mailcow` with the patched runner:

| scenario | before | after |
|---|---|---|
| lock file with a **dead** PID | `can't lock /tmp/imapsync_busy at ... line 42.` | breaks the stale lock (`UNLOCKED /tmp/imapsync_busy (stale lock by PID 31337)`), runner proceeds, lock file cleaned up on exit |
| lock file held by a **live** process | refuses | still refuses, lock file left intact |

So recovery is automatic, and a lock held by a genuinely running imapsync is still honoured — concurrent runs remain prevented.

Fixes #7373