### PR TITLE
[Web] do not abort domain edit on an already assigned tag

### DIFF
--- a/data/web/inc/functions.mailbox.inc.php
+++ b/data/web/inc/functions.mailbox.inc.php
@@ -634,11 +634,15 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
               );
               break;
             }
-            $stmt = $pdo->prepare("INSERT INTO `tags_domain` (`domain`, `tag_name`) VALUES (:domain, :tag_name)");
-            $stmt->execute(array(
-              ':domain' => $domain,
-              ':tag_name' => $tag,
-            ));
+            try {
+              $stmt = $pdo->prepare("INSERT INTO `tags_domain` (`domain`, `tag_name`) VALUES (:domain, :tag_name)");
+              $stmt->execute(array(
+                ':domain' => $domain,
+                ':tag_name' => $tag,
+              ));
+            } catch (Exception $e) {
+              // tag already assigned to this domain, skip it
+            }
           }
 
           try {
@@ -2847,11 +2851,15 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                   );
                   break;
                 }
-                $stmt = $pdo->prepare("INSERT INTO `tags_domain` (`domain`, `tag_name`) VALUES (:domain, :tag_name)");
-                $stmt->execute(array(
-                  ':domain' => $domain,
-                  ':tag_name' => $tag,
-                ));
+                try {
+                  $stmt = $pdo->prepare("INSERT INTO `tags_domain` (`domain`, `tag_name`) VALUES (:domain, :tag_name)");
+                  $stmt->execute(array(
+                    ':domain' => $domain,
+                    ':tag_name' => $tag,
+                  ));
+                } catch (Exception $e) {
+                  // tag already assigned to this domain, skip it
+                }
               }
 
               $_SESSION['return'][] = array(
@@ -3015,11 +3023,15 @@ function mailbox($_action, $_type, $_data = null, $_extra = null) {
                   );
                   break;
                 }
-                $stmt = $pdo->prepare("INSERT INTO `tags_domain` (`domain`, `tag_name`) VALUES (:domain, :tag_name)");
-                $stmt->execute(array(
-                  ':domain' => $domain,
-                  ':tag_name' => $tag,
-                ));
+                try {
+                  $stmt = $pdo->prepare("INSERT INTO `tags_domain` (`domain`, `tag_name`) VALUES (:domain, :tag_name)");
+                  $stmt->execute(array(
+                    ':domain' => $domain,
+                    ':tag_name' => $tag,
+                  ));
+                } catch (Exception $e) {
+                  // tag already assigned to this domain, skip it
+                }
               }
 
               $_SESSION['return'][] = array(


### PR DESCRIPTION
## Description

`tags_domain` has a unique key on `(tag_name, domain)`. The tag widget keeps the full tag list in a hidden field and submits **all** tags on save, so saving a domain that already carries a tag re-inserts it and the INSERT raises a duplicate key exception.

Nothing catches it on the domain paths, so the remaining tags in the list are never inserted and the request ends without adding its success message — the API answers HTTP 200 with an empty body and the newly added tag is silently lost. In practice a tag can only be added while the domain still has no tags.

All three `tags_mailbox` inserts already guard against this with a `try { ... } catch (Exception $e) {}`. This applies the same guard to the three `tags_domain` inserts (domain add, and both domain edit branches), so an already assigned tag is skipped instead of aborting the rest of the operation.

## Verification

Live stack, checking `tags_domain` directly in MariaDB:

| scenario | before | after |
|---|---|---|
| domain has `alpha`, save `["alpha","beta"]` | empty 200 response, `beta` lost | success response, tags are `alpha, beta` |
| then save `["alpha","beta","gamma"]` | — | tags are `alpha, beta, gamma` |
| `add/domain` with `tags: ["x","x","y"]` | aborts | domain created, tags are `x, y` |
| duplicate rows created | — | none |

Regression checks: a plain description edit still applies, and mailbox tags still behave as before.

Fixes #7379

---

Note: this touches the same lines as #7377. Whichever is merged first, I'm happy to rebase the other.