### PR TITLE
[Web] use a real origin as the CORS fallback

### DIFF
--- a/data/web/inc/functions.inc.php
+++ b/data/web/inc/functions.inc.php
@@ -2370,8 +2370,8 @@ function cors($action, $data = null) {
         );
       }
 
-      $cors_settings                    = !$cors_settings ? array('allowed_origins' => $_SERVER['SERVER_NAME'], 'allowed_methods' => 'GET, POST, PUT, DELETE') : $cors_settings;
-      $cors_settings['allowed_origins'] = empty($cors_settings['allowed_origins']) ? $_SERVER['SERVER_NAME'] : $cors_settings['allowed_origins'];
+      $cors_settings                    = !$cors_settings ? array('allowed_origins' => getBaseURL(), 'allowed_methods' => 'GET, POST, PUT, DELETE') : $cors_settings;
+      $cors_settings['allowed_origins'] = empty($cors_settings['allowed_origins']) ? getBaseURL() : $cors_settings['allowed_origins'];
       $cors_settings['allowed_methods'] = empty($cors_settings['allowed_methods']) ? 'GET, POST, PUT, DELETE, OPTION' : $cors_settings['allowed_methods'];
 
       return $cors_settings;


### PR DESCRIPTION
## Description

Follow-up to #7333, which fixed the settings side of #7332: `allowed_origins` is now validated as a full origin and its default there is `getBaseURL()`.

The fallback on the **read** path was not updated and still substitutes a bare `$_SERVER['SERVER_NAME']`:

```php
$cors_settings                    = !$cors_settings ? array('allowed_origins' => $_SERVER['SERVER_NAME'], ...) : $cors_settings;
$cors_settings['allowed_origins'] = empty($cors_settings['allowed_origins']) ? $_SERVER['SERVER_NAME'] : $cors_settings['allowed_origins'];
```

On any installation that never saved CORS settings explicitly, `cors('get')` therefore hands a host name to code that expects an origin. The browser sends `Origin: https://mail.example.com`, the `in_array()` match against `mail.example.com` fails, and `Access-Control-Allow-Origin` is answered with the bare host — which no browser accepts.

This uses `getBaseURL()` for both fallbacks, so the read path defaults to the same `scheme://host` form the save path already writes.

## Verification

Live stack with `CORS_SETTINGS` deleted from Redis so the fallback applies:

| request | before | after |
|---|---|---|
| `Origin: http://mail.local.test`, Host `mail.local.test` | `Access-Control-Allow-Origin: mail.local.test` | `Access-Control-Allow-Origin: http://mail.local.test` (exact match, echoed back) |
| `Origin: http://127.0.0.1:8090` | `Access-Control-Allow-Origin: 127.0.0.1` | `Access-Control-Allow-Origin: http://127.0.0.1` |

Verified over plain HTTP, so the scheme shown is `http`; `getBaseURL()` derives it from the request, so a TLS deployment yields `https://...` and matches the origin a browser actually sends.

As with the default `getBaseURL()` already used on the save path, a deployment served on a non-standard port still needs an explicit setting, since the helper does not include a port.

Refs #7332