### PR TITLE
[Netfilter][Watchdog] Use source IP for ban notification WHOIS lookups

### DIFF
--- a/data/Dockerfiles/netfilter/main.py
+++ b/data/Dockerfiles/netfilter/main.py
@@ -176,6 +176,9 @@ def ban(address):
 
     logdebug("Updating F2B_ACTIVE_BANS[%s]=%d" %
               (net, cur_time + NET_BAN_TIME))
+    # Store the triggering IP before recording the active ban so watchdog
+    # can use it for WHOIS lookups.
+    r.hset('F2B_ACTIVE_BAN_SOURCE_IP_ADDRESS', '%s' % net, address)
     r.hset('F2B_ACTIVE_BANS', '%s' % net, cur_time + NET_BAN_TIME)
   else:
     logger.logWarn('%d more attempts in the next %d seconds until %s is banned' % (
@@ -199,6 +202,7 @@ def unban(net):
       logdebug("Calling tables.unbanIPv6(%s)" % net)
       tables.unbanIPv6(net)
   r.hdel('F2B_ACTIVE_BANS', '%s' % net)
+  r.hdel('F2B_ACTIVE_BAN_SOURCE_IP_ADDRESS', '%s' % net)
   r.hdel('F2B_QUEUE_UNBAN', '%s' % net)
   if net in bans:
     logdebug("Unban for %s, setting attempts=0, ban_counter+=1" % net)
@@ -245,9 +249,10 @@ def clear():
     try:
       if r is not None:
         r.delete('F2B_ACTIVE_BANS')
+        r.delete('F2B_ACTIVE_BAN_SOURCE_IP_ADDRESS')
         r.delete('F2B_PERM_BANS')
     except Exception as ex:
-      logger.logWarn('Error clearing redis keys F2B_ACTIVE_BANS and F2B_PERM_BANS: %s' % ex)
+      logger.logWarn('Error clearing Redis ban keys: %s' % ex)
 
 def watch():
   global pubsub
@@ -495,6 +500,7 @@ if __name__ == '__main__':
     logdebug("Renaming F2B_LOG to NETFILTER_LOG")
     r.rename('F2B_LOG', 'NETFILTER_LOG')
   r.delete('F2B_ACTIVE_BANS')
+  r.delete('F2B_ACTIVE_BAN_SOURCE_IP_ADDRESS')
   r.delete('F2B_PERM_BANS')
 
   refreshF2boptions()

--- a/data/Dockerfiles/watchdog/watchdog.sh
+++ b/data/Dockerfiles/watchdog/watchdog.sh
@@ -1132,12 +1132,18 @@ while true; do
     F2B_RES=($(timeout 4s ${REDIS_CMDLINE} --raw GET F2B_RES 2> /dev/null))
     if [[ ! -z "${F2B_RES}" ]]; then
       ${REDIS_CMDLINE} DEL F2B_RES > /dev/null
-      host=
-      for host in "${F2B_RES[@]}"; do
-        log_msg "Banned ${host}"
+      banned_net=
+      for banned_net in "${F2B_RES[@]}"; do
+        log_msg "Banned ${banned_net}"
         rm /tmp/fail2ban 2> /dev/null
-        timeout 2s whois "${host}" > /tmp/fail2ban
-        [[ ${WATCHDOG_NOTIFY_BAN} =~ ^([yY][eE][sS]|[yY])+$ ]] && notify_error "${com_pipe_answer}" "IP ban: ${host}"
+        # CIDR WHOIS queries may not return useful registration data.
+        # Prefer the triggering IP, falling back to the network address if unavailable.
+        whois_ip_address="$(${REDIS_CMDLINE} --raw HGET F2B_ACTIVE_BAN_SOURCE_IP_ADDRESS "${banned_net}" 2> /dev/null)"
+        if [[ -z "${whois_ip_address}" ]]; then
+          whois_ip_address="${banned_net%%/*}"
+        fi
+        timeout 2s whois "${whois_ip_address}" > /tmp/fail2ban
+        [[ ${WATCHDOG_NOTIFY_BAN} =~ ^([yY][eE][sS]|[yY])+$ ]] && notify_error "${com_pipe_answer}" "IP ban: ${banned_net}"
       done
     fi
   elif [[ ${com_pipe_answer} =~ .+-mailcow ]]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -506,7 +506,7 @@ services:
             - acme
 
     netfilter-mailcow:
-      image: ghcr.io/mailcow/netfilter:1.64
+      image: ghcr.io/mailcow/netfilter:1.64a
       stop_grace_period: 30s
       restart: always
       privileged: true
@@ -526,7 +526,7 @@ services:
         - /lib/modules:/lib/modules:ro
 
     watchdog-mailcow:
-      image: ghcr.io/mailcow/watchdog:2.11
+      image: ghcr.io/mailcow/watchdog:2.11a
       dns:
         - ${IPV4_NETWORK:-172.22.1}.254
       tmpfs:


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Fail2ban can expand the address that triggered a ban into a configured network range, such as `/24`. Watchdog currently passes that CIDR range to `whois`, which may not return useful registration data.

This change stores the triggering IP in a separate Redis hash keyed by the banned network. Watchdog uses that IP for its WHOIS lookup and falls back to the network address when no source mapping is available.

`F2B_ACTIVE_BANS` remains keyed by the banned network, preserving existing firewall, Web UI, and unban behavior.

This addresses #6843 and implements the separate-key approach discussed in #4759.

### Affected Containers

- netfilter-mailcow
- watchdog-mailcow

## Did you run tests?

### What did you tested?

- Parsed `netfilter/main.py` with Python's AST parser.
- Validated `watchdog.sh` with `bash -n`.
- Validated the Compose configuration with `docker-compose config --quiet`.
- Checked whitespace and preserved the existing CRLF/no-final-newline format of `netfilter/main.py`.
- Built local netfilter and watchdog images and deployed them on an active mailcow installation.
- Tested a synthetic `/24` ban mapping and then observed multiple naturally generated ban notifications.

### What were the final results? (Awaited, got)

Expected:

- Continue displaying and enforcing the configured banned network.
- Query WHOIS using the individual IP that triggered the ban.
- Include complete registration data in watchdog ban notifications.
- Fall back safely when no source-IP mapping exists.

Got:

- Firewall and Redis active-ban entries continued to use the configured network.
- Watchdog notifications continued to identify the banned network.
- Synthetic and naturally generated notifications returned complete WHOIS registration data instead of the CIDR-query error.
- Python, Bash, Compose, and whitespace checks all passed.