### PR TITLE
[Rspamd] update to 4.1.4

### DIFF
--- a/data/Dockerfiles/rspamd/Dockerfile
+++ b/data/Dockerfiles/rspamd/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:trixie-slim
 LABEL maintainer="The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG RSPAMD_VER=rspamd_4.1.0-1~e2b0b18
+ARG RSPAMD_VER=rspamd_4.1.4-1~beb659b
 ARG CODENAME=trixie
 ENV LC_ALL=C
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
             - clamd
 
     rspamd-mailcow:
-      image: ghcr.io/mailcow/rspamd:4.1.0-1
+      image: ghcr.io/mailcow/rspamd:4.1.4-1
       stop_grace_period: 30s
       depends_on:
         - dovecot-mailcow


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the contribution guidelines and wholeheartedly agree them

## What does this PR include?

### Short Description

Updates rspamd from 4.1.0 to 4.1.4 (security + bugfixes, incl. controller auth
fail-open fix and regexp/parser hardening). No config changes.

### Affected Containers

- rspamd-mailcow

## Did you run tests?

### What did you tested?

Built the rspamd image and ran the stack
