### PR TITLE
[Web] Create default mailbox template with eas and dav access

### DIFF
--- a/data/web/inc/init_db.inc.php
+++ b/data/web/inc/init_db.inc.php
@@ -1464,6 +1464,8 @@ function init_db_schema()
         "pop3_access" => intval($GLOBALS['MAILBOX_DEFAULT_ATTRIBUTES']['pop3_access']),
         "smtp_access" => intval($GLOBALS['MAILBOX_DEFAULT_ATTRIBUTES']['smtp_access']),
         "sieve_access" => intval($GLOBALS['MAILBOX_DEFAULT_ATTRIBUTES']['sieve_access']),
+        "eas_access" => intval($GLOBALS['MAILBOX_DEFAULT_ATTRIBUTES']['eas_access']),
+        "dav_access" => intval($GLOBALS['MAILBOX_DEFAULT_ATTRIBUTES']['dav_access']),
         "acl_spam_alias" => 1,
         "acl_tls_policy" => 1,
         "acl_spam_score" => 1,


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the contribution guidelines and wholeheartedly agree them

## What does this PR include?

### Short Description

Adds the missing `eas_access` and `dav_access` attributes to the default mailbox
template when it is first seeded in init_db.

### Affected Containers

- php-fpm-mailcow

