### PR TITLE
[Web] accept IDN domains when logging in

### DIFF
--- a/data/web/inc/functions.auth.inc.php
+++ b/data/web/inc/functions.auth.inc.php
@@ -1,4 +1,22 @@
 <?php
+// Normalize a login name to the form usernames are stored in.
+// Every write path runs domains through idn_to_ascii, so an IDN domain is only
+// ever stored as punycode. Without the same conversion here an IDN login is
+// rejected as malformed and would not match the stored username either.
+// Names without a domain part (admin logins) are returned unchanged.
+function normalize_login_name($login_name) {
+  $login_name = strtolower(trim($login_name));
+  $at = strrpos($login_name, '@');
+  if ($at === false) {
+    return $login_name;
+  }
+  $domain = idn_to_ascii(substr($login_name, $at + 1), 0, INTL_IDNA_VARIANT_UTS46);
+  if ($domain === false) {
+    return $login_name;
+  }
+  return substr($login_name, 0, $at) . '@' . $domain;
+}
+
 function check_login($user, $pass, $extra = null) {
   global $pdo;
   global $redis;

--- a/data/web/inc/triggers.admin.inc.php
+++ b/data/web/inc/triggers.admin.inc.php
@@ -57,7 +57,7 @@ if (isset($_GET["cancel_tfa_setup"])) {
 }
 
 if (isset($_POST["login_user"]) && isset($_POST["pass_user"])) {
-  $login_user = strtolower(trim($_POST["login_user"]));
+  $login_user = normalize_login_name($_POST["login_user"]);
   $as = check_login($login_user, $_POST["pass_user"], array("role" => "admin", "service" => "MAILCOWUI"));
 
   if ($as == "admin") {

--- a/data/web/inc/triggers.domainadmin.inc.php
+++ b/data/web/inc/triggers.domainadmin.inc.php
@@ -68,7 +68,7 @@ if (isset($_GET["cancel_tfa_setup"])) {
 }
 
 if (isset($_POST["login_user"]) && isset($_POST["pass_user"])) {
-  $login_user = strtolower(trim($_POST["login_user"]));
+  $login_user = normalize_login_name($_POST["login_user"]);
   $as = check_login($login_user, $_POST["pass_user"], array("role" => "domain_admin", "service" => "MAILCOWUI"));
 
   if ($as == "domainadmin") {

--- a/data/web/inc/triggers.user.inc.php
+++ b/data/web/inc/triggers.user.inc.php
@@ -132,7 +132,7 @@ if (isset($_GET["cancel_tfa_setup"])) {
 }
 
 if (isset($_POST["login_user"]) && isset($_POST["pass_user"])) {
-  $login_user = strtolower(trim($_POST["login_user"]));
+  $login_user = normalize_login_name($_POST["login_user"]);
   $as = check_login($login_user, $_POST["pass_user"], array("role" => "user", "service" => "MAILCOWUI"));
 
   if ($as == "user") {


### PR DESCRIPTION
## Description

Domains and mailboxes are stored with their domain part converted to punycode — every write path runs it through `idn_to_ascii(..., INTL_IDNA_VARIANT_UTS46)` (e.g. `functions.mailbox.inc.php:508`, `:1039`). Adding `exümple.org` stores `xn--exmple-4ya.org`, and the mailbox is stored as `test@xn--exmple-4ya.org`.

The login handlers never applied that conversion, so a login as `test@exümple.org` failed in **two** independent ways:

1. The format guard shared by all six `*_login()` functions in `functions.auth.inc.php` (lines 73, 138, 207, 441, 499, 638) is

   ```php
   if (!filter_var($user, FILTER_VALIDATE_EMAIL) && !ctype_alnum(str_replace(array('_', '.', '-'), '', $user))) {
   ```

   `FILTER_VALIDATE_EMAIL` rejects non-ASCII, and the `ctype_alnum` fallback rejects the `@`, so the request never reached the database and the user got `malformed_username` ("Malformed username", as reported).

2. Even past that guard the lookup is `WHERE username = :user` against the punycode form, so the IDN string matches nothing. Confirmed against the DB:

   ```
   SELECT COUNT(*) FROM mailbox WHERE username = 'test@exümple.org';        -- 0
   SELECT COUNT(*) FROM mailbox WHERE username = 'test@xn--exmple-4ya.org'; -- 1
   ```

   Because of (2), relaxing the format check alone would not have fixed this — the submitted name has to be converted, not just accepted.

This adds `normalize_login_name()` next to those guards and uses it where the three UI login handlers already did `strtolower(trim(...))`, so the converted name is what gets authenticated *and* what is stored in the session. A name with no domain part is returned unchanged, leaving admin logins untouched, and `idn_to_ascii()` returning `false` falls back to the submitted value so malformed input is still rejected exactly as before.

UTS46 also case-folds, which byte-wise `strtolower()` cannot do for non-ASCII: `TEST@EXÜMPLE.ORG` now normalizes correctly, where previously `strtolower()` left `Ü` untouched.

## Verification

Live web tier on `staging` (`d1a2f4e1`), domain `exümple.org` + mailbox `test@exümple.org` created through the API. Before/after captured with the same probe, swapping only these files and force-recreating `php-fpm-mailcow` between runs (opcache runs with `validate_timestamps=Off`); the live code inside the container was grepped before each run to confirm which version was actually being served.

| login attempt | before | after |
|---|---|---|
| `test@exümple.org` (correct pw) | rejected — *Malformed username* | **logged in** → `/user` |
| `TEST@EXÜMPLE.ORG` (correct pw) | rejected — *Malformed username* | **logged in** → `/user` |
| `test@xn--exmple-4ya.org` (correct pw) | logged in | logged in |
| `plain@ascii.test` (correct pw) | logged in | logged in |
| admin `admin` | logged in | logged in |
| domain admin `da_test` | logged in | logged in |
| `test@exümple.org` + wrong pw | rejected | rejected |
| nonexistent `nope@exümple.org` | rejected | rejected |
| malformed `a@b@exümple.org` | rejected | rejected |

After an IDN login the session resolves to the stored name — `/user` renders `test@xn--exmple-4ya.org` throughout, with no occurrence of the unconverted form, so the session is consistent with what every other lookup expects.

The helper was also exercised directly against the container's PHP/ICU for idempotency and edge cases: already-punycode input is unchanged, non-Latin IDN (`test@例え.テスト` → `test@xn--r8jz45g.xn--zckzah`) converts, and `a@b@…`, `test@`, empty and over-long domains fall through to the unchanged value and are still rejected by the existing guard. `normalize_login_name(normalize_login_name($x)) === normalize_login_name($x)` for every case.

`php -l` clean on all four files.

## Scope

Deliberately limited to the three UI login handlers, so paths that do not currently accept IDN keep behaving exactly as they do today rather than changing in ways this could not verify:

- `sogo-auth.php` and the OAuth2 `checkUserCredentials()` in `prerequisites.inc.php` pass their username to `check_login()` and then reuse the raw value (`X-User`, user lookup). Normalizing inside `check_login()` would make those authenticate an IDN name but hand the unconverted form downstream, and SOGo is not exercisable here (`SKIP_SOGO=y`).
- Dovecot/IMAP authenticates separately and is untouched.
- The password-reset request (`reset_password("issue", $_POST['username'])`) takes a username on the same page and has the same gap; left alone as a separate change.

Happy to widen it if you'd prefer the conversion inside `check_login()` instead.

Fixes #7395
