### PR TITLE
Modifica i parametri di creazione per FIDO2 e TFA in json_api.php

### DIFF
--- a/data/web/json_api.php
+++ b/data/web/json_api.php
@@ -370,7 +370,7 @@ if (isset($_GET['query'])) {
           if (isset($_SESSION["mailcow_cc_role"])) {
               // Exclude existing CredentialIds, if any
               $excludeCredentialIds = fido2(array("action" => "get_user_cids"));
-              $createArgs = $WebAuthn->getCreateArgs($_SESSION["mailcow_cc_username"], $_SESSION["mailcow_cc_username"], $_SESSION["mailcow_cc_username"], 30, true, $GLOBALS['FIDO2_UV_FLAG_REGISTER'], null, $excludeCredentialIds);
+              $createArgs = $WebAuthn->getCreateArgs($_SESSION["mailcow_cc_username"] . '-fido2', $_SESSION["mailcow_cc_username"] . ' (FIDO2)', $_SESSION["mailcow_cc_username"] . ' (FIDO2)', 30, true, $GLOBALS['FIDO2_UV_FLAG_REGISTER'], null, $excludeCredentialIds);
               print(json_encode($createArgs));
               $_SESSION['challenge'] = $WebAuthn->getChallenge();
               return;
@@ -410,7 +410,7 @@ if (isset($_GET['query'])) {
               // cross-platform: true, if type internal is not allowed
               //        false, if only internal is allowed
               //        null, if internal and cross-platform is allowed
-              $createArgs = $WebAuthn->getCreateArgs($_SESSION["mailcow_cc_username"], $_SESSION["mailcow_cc_username"], $_SESSION["mailcow_cc_username"], 30, false, $GLOBALS['WEBAUTHN_UV_FLAG_REGISTER'], null, $excludeCredentialIds);
+              $createArgs = $WebAuthn->getCreateArgs($_SESSION["mailcow_cc_username"] . '-tfa', $_SESSION["mailcow_cc_username"] . ' (TFA)', $_SESSION["mailcow_cc_username"] . ' (TFA)', 30, false, $GLOBALS['WEBAUTHN_UV_FLAG_REGISTER'], null, $excludeCredentialIds);
 
               print(json_encode($createArgs));
               $_SESSION['challenge'] = $WebAuthn->getChallenge();


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

Fix WebAuthn/FIDO2 credential overwriting issue in OS/browser passkey managers. 

Previously, both FIDO2 (passwordless) and WebAuthn 2FA registrations passed the raw username as `$userId` and username string to `getCreateArgs()`. As a result, browser and OS credential managers (Windows Hello, Apple Keychain, Bitwarden, etc.) treated the second registered key as an update to the first one for the same RP ID and overwrote it.

This PR adds distinct `-fido2` and `-2fa` suffixes to the `$userId` parameter (and `(FIDO2)` / `(2FA)` to display names) in `data/web/json_api.php`, ensuring that passkey managers store both credentials as separate entities.
<!-- Please write a short description, what your PR does here. -->

###  Affected Containers
- php-fpm-mailcow
<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->

## Did you run tests?

### What did you tested?

- WebAuthn TFA (2FA) key registration for user `admin`.
- FIDO2 (Passwordless) key registration for the same user `admin`.
- Inspection of saved passkeys/credentials inside the browser/OS key manager.
- Authentication tests using both 2FA and FIDO2 login flows.
<!-- Please write shortly, what you've tested (which components etc.). -->

### What were the final results? (Awaited, got)

- **Awaited:** OS/browser credential manager should treat WebAuthn 2FA and FIDO2 as distinct credentials for the same user without overwriting existing keys.
- **Got:** Both keys are stored separately (`admin (2FA)` and `admin (FIDO2)`), neither overwrites the other, and both authentication methods work as expected.

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->