### PR TITLE
[Clamd] Update to 1.4.6

### DIFF
--- a/data/Dockerfiles/clamd/Dockerfile
+++ b/data/Dockerfiles/clamd/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.21 AS builder
+FROM alpine:3.24 AS builder
 
 WORKDIR /src
-ENV CLAMD_VERSION=1.4.2
+ENV CLAMD_VERSION=1.4.6
 
 RUN apk upgrade --no-cache \
   && apk add --update --no-cache \
@@ -68,7 +68,7 @@ RUN wget -P /src https://www.clamav.net/downloads/production/clamav-${CLAMD_VERS
   "/clamav/etc/clamav/clamav-milter.conf.sample" > "/clamav/etc/clamav/clamav-milter.conf" || exit 1
 
 
-FROM alpine:3.21
+FROM alpine:3.24
 
 LABEL maintainer = "The Infrastructure Company GmbH <info@servercow.de>"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
             - redis
 
     clamd-mailcow:
-      image: ghcr.io/mailcow/clamd:1.71
+      image: ghcr.io/mailcow/clamd:1.4.6-1
       restart: always
       depends_on:
         unbound-mailcow:


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Bump ClamAV from 1.4.2 to 1.4.6 to patch 8 CVEs disclosed in the 1.4.6/1.5.4 release, most notably CVE-2026-20337 and CVE-2026-20338 (high-severity DoS via crafted ZIP/PDF files, PoC public).

The 1.4.6 source vendors a Rust dep that requires `edition2024` (Cargo ≥ 1.85), which Alpine 3.21 does not ship. The clamd build image is therefore bumped from Alpine 3.21 to Alpine 3.24.

### Affected Containers

- clamd-mailcow

## Did you run tests?

### What did you tested?

- Image rebuild on Alpine 3.24
- Container startup and healthcheck
- `clamd --version` / `freshclam --version` inside the container
- freshclam signature update
- Direct EICAR scan via `clamdscan` (unix socket) and clean-file scan
- clamd TCP:3310 reachability from rspamd
- End-to-end: EICAR mail piped through `rspamc symbols` (rspamd → clamd)

### What were the final results? (Awaited, got)

- Awaited: ClamAV 1.4.6 running, signatures loaded, EICAR flagged, mail path rejects virus. Got: exactly that.
- Container `healthy`, ClamAV 1.4.6 on Alpine 3.24.1, signatures up-to-date.
- Direct EICAR scan → `Eicar-Test-Signature FOUND`; clean file → `OK`.
- End-to-end EICAR via rspamc → `Symbol: VIRUS_FOUND (2000.00)`, `Action: reject`.