### PR TITLE
feat: add aliases to mobileconfig

### DIFF
--- a/data/web/js/site/user.js
+++ b/data/web/js/site/user.js
@@ -701,4 +701,18 @@ jQuery(function($){
   onVisible("[id^=sync_job_table]", () => draw_sync_job_table());
   onVisible("[id^=app_passwd_table]", () => draw_app_passwd_table());
   onVisible("[id^=recent-logins]", () => last_logins('get'));
+
+  // Toggle aliases in mobileconfig links
+  $('#mobileconfig-with-aliases').on('change', function() {
+    $('.mobileconfig-link').each(function() {
+      var url = new URL($(this).attr('href'), window.location.origin);
+      if ($('#mobileconfig-with-aliases').is(':checked')) {
+        url.searchParams.set('with_aliases', '');
+      } else {
+        url.searchParams.delete('with_aliases');
+      }
+      var query = url.searchParams.toString();
+      $(this).attr('href', query ? url.pathname + '?' + query : url.pathname);
+    });
+  });
 });

--- a/data/web/lang/lang.en-gb.json
+++ b/data/web/lang/lang.en-gb.json
@@ -1274,6 +1274,7 @@
         "apple_connection_profile_complete": "This connection profile includes IMAP and SMTP parameters as well as CalDAV (calendars) and CardDAV (contacts) paths for an Apple device.",
         "apple_connection_profile_mailonly": "This connection profile includes IMAP and SMTP configuration parameters for an Apple device.",
         "apple_connection_profile_with_app_password": "A new app password is generated and added to the profile so that no password needs to be entered when setting up your device. Please do not share the file as it grants full access to your mailbox.",
+        "apple_connection_profile_include_aliases": "Include mailbox aliases as additional email addresses in the profile",
         "attribute": "Attribute",
         "authentication": "Authentication",
         "change_password": "Change password",

--- a/data/web/mobileconfig.php
+++ b/data/web/mobileconfig.php
@@ -32,6 +32,14 @@ catch(PDOException $e) {
   $displayname = $email;
 }
 
+$emailAddresses = $email;
+if (isset($_GET['with_aliases'])) {
+  $aliasDetails = user_get_alias_details($email);
+  if (!empty($aliasDetails['direct_aliases'])) {
+    $emailAddresses = implode(',', array_merge(array($email), array_keys($aliasDetails['direct_aliases'])));
+  }
+}
+
 if (isset($_GET['only_email'])) {
   $onlyEmailAccount = true;
   $description = 'IMAP';
@@ -85,7 +93,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
         <key>EmailAccountName</key>
         <string><?=$displayname?></string>
         <key>EmailAddress</key>
-        <string><?=$email?></string>
+        <string><?=$emailAddresses?></string>
         <key>IncomingMailServerAuthentication</key>
         <string>EmailAuthPassword</string>
         <key>IncomingMailServerHostName</key>

--- a/data/web/mobileconfig.php
+++ b/data/web/mobileconfig.php
@@ -36,7 +36,7 @@ $emailAddresses = $email;
 if (isset($_GET['with_aliases'])) {
   $aliasDetails = user_get_alias_details($email);
   if (!empty($aliasDetails['direct_aliases'])) {
-    $emailAddresses = implode(',', array_merge(array($email), array_keys($aliasDetails['direct_aliases'])));
+    $emailAddresses = implode(', ', array_merge(array($email), array_keys($aliasDetails['direct_aliases'])));
   }
 }
 

--- a/data/web/templates/user/tab-user-auth.twig
+++ b/data/web/templates/user/tab-user-auth.twig
@@ -67,12 +67,12 @@
             <div class="col-12 col-md-8">
               <div class="d-flex">
                 <i style="font-size: 16px; cursor: pointer;" class="bi bi-patch-question-fill me-2" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom" title="{{ lang.user.apple_connection_profile_mailonly }}"></i>
-                <a href="/mobileconfig.php?only_email">{{ lang.user.email }} <small>[IMAP, SMTP]</small></a>
+                <a class="mobileconfig-link" href="/mobileconfig.php?only_email">{{ lang.user.email }} <small>[IMAP, SMTP]</small></a>
               </div>
               {% if not skip_sogo %}
               <div class="d-flex">
                 <i style="font-size: 16px; cursor: pointer;" class="bi bi-patch-question-fill me-2" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom" title="{{ lang.user.apple_connection_profile_complete }}"></i>
-                <a href="/mobileconfig.php">{{ lang.user.email_and_dav }} <small>[IMAP, SMTP, Cal/CardDAV]</small></a>
+                <a class="mobileconfig-link" href="/mobileconfig.php">{{ lang.user.email_and_dav }} <small>[IMAP, SMTP, Cal/CardDAV]</small></a>
               </div>
               {% endif %}
             </div>
@@ -84,14 +84,23 @@
             <div class="col-12 col-md-9">
               <div class="d-flex">
                 <i style="font-size: 16px; cursor: pointer;" class="bi bi-patch-question-fill me-2" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom" title="{{ lang.user.apple_connection_profile_mailonly }} {{ lang.user.apple_connection_profile_with_app_password }}"></i>
-                <a href="/mobileconfig.php?only_email&amp;app_password">{{ lang.user.email }} <small>[IMAP, SMTP]</small></a>
+                <a class="mobileconfig-link" href="/mobileconfig.php?only_email&amp;app_password">{{ lang.user.email }} <small>[IMAP, SMTP]</small></a>
               </div>
               {% if not skip_sogo %}
               <div class="d-flex">
                 <i style="font-size: 16px; cursor: pointer;" class="bi bi-patch-question-fill me-2" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom" title="{{ lang.user.apple_connection_profile_complete }} {{ lang.user.apple_connection_profile_with_app_password }}"></i>
-                <a href="/mobileconfig.php?app_password">{{ lang.user.email_and_dav }} <small>[IMAP, SMTP, Cal/CardDAV]</small></a>
+                <a class="mobileconfig-link" href="/mobileconfig.php?app_password">{{ lang.user.email_and_dav }} <small>[IMAP, SMTP, Cal/CardDAV]</small></a>
               </div>
               {% endif %}
+            </div>
+          </div>
+          <div class="row mt-2">
+            <div class="col-12 col-md-3 d-flex"></div>
+            <div class="col-12 col-md-9">
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="mobileconfig-with-aliases">
+                <label class="form-check-label" for="mobileconfig-with-aliases">{{ lang.user.apple_connection_profile_include_aliases }}</label>
+              </div>
             </div>
           </div>
           <div class="row">


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items, otherwise we might refuse your PR:_ -->

## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

<!-- _NOTE: this tickbox is needed to fullfil on order to get your PR reviewed._ -->

## What does this PR include?

### Short Description

<!-- Please write a short description, what your PR does here. -->
This change allows the user to generate an Apple MobileConfig which includes the user personal aliases with a simple checkbox on the user settings page ( #4828 ).
user.js checks if the box is ticked and the mobileconfig.php then decides on that if the aliases should also be put into the xml.

###  Affected Containers

<!-- Please list all affected Docker containers here, which you commited changes to -->

<!--

Please list them like this:

- container1
- container2
- container3
etc.

-->
- php-fpm-mailcow
- nginx-mailcow

## Did you run tests?

Yes I did test the changes applied to the version 2026.07a.
<img width="542" height="123" alt="image" src="https://github.com/user-attachments/assets/e96471c0-0235-45e7-9351-ace6216e14bf" />


### What did you test?

<!-- Please write shortly, what you've tested (which components etc.). -->
I tested that both affected containers are still working correctly after adding the changed code.
Additionally, I checked that the user settings page correctly renders. And finally I checked that the resulting XML is actually behaving as expected with and without the additional alias toggle enabled. 
 
### What were the final results? (Awaited, got)

<!-- Please write shortly, what your final tests results were. What did you awaited? Was the outcome the awaited one? -->
#### UI
UI twig seems to show the box correctly.
<img width="853" height="414" alt="image" src="https://github.com/user-attachments/assets/8c4f82d9-5ba8-4c72-a945-fcbaa6f522e4" />

#### Function
Creating a user with 2 direct and one shared alias resulted in the correct xml.
<img width="1318" height="251" alt="image" src="https://github.com/user-attachments/assets/8d004875-1f32-4b5a-a57b-f2fcc0799c7b" />

```xml
        <key>EmailAccountDescription</key>
        <string>testuser@magicbroccoli.de</string>
        <key>EmailAccountType</key>
        <string>EmailTypeIMAP</string>
        <key>EmailAccountName</key>
        <string>test</string>
        <key>EmailAddress</key>
        <string>testuser@magicbroccoli.de, testuser_alias1@magicbroccoli.de, testuser_alias2@magicbroccoli.de</string>
```
testuser_alias3@ is shared and is therefore excluded.

Not ticking the box resulted in the current behavior of only having one alias listed in the resulting xml.
```xml
        <key>EmailAccountDescription</key>
        <string>testuser@magicbroccoli.de</string>
        <key>EmailAccountType</key>
        <string>EmailTypeIMAP</string>
        <key>EmailAccountName</key>
        <string>test</string>
        <key>EmailAddress</key>
        <string>testuser@magicbroccoli.de</string>
```