### PR TITLE
[SOGo] Update to 5.12.10

### DIFF
--- a/data/Dockerfiles/sogo/Dockerfile
+++ b/data/Dockerfiles/sogo/Dockerfile
@@ -12,8 +12,8 @@ FROM debian:bookworm
 LABEL maintainer="The Infrastructure Company GmbH <info@servercow.de>"
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG SOGO_VERSION=SOGo-5.12.9
-ARG SOPE_VERSION=SOPE-5.12.9
+ARG SOGO_VERSION=SOGo-5.12.10
+ARG SOPE_VERSION=SOPE-5.12.10
 # Security patches to apply (space-separated commit hashes)
 ARG SOGO_SECURITY_PATCHES=""
 # renovate: datasource=github-releases depName=tianon/gosu versioning=semver-coerced extractVersion=^(?<version>.*)$

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,7 @@ services:
             - phpfpm
 
     sogo-mailcow:
-      image: ghcr.io/mailcow/sogo:5.12.9-1
+      image: ghcr.io/mailcow/sogo:5.12.10-1
       environment:
         - DBNAME=${DBNAME}
         - DBUSER=${DBUSER}


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Updates SOGo from 5.12.9 to 5.12.10. Bumps `SOGO_VERSION`/`SOPE_VERSION` in the sogo Dockerfile and the `sogo-mailcow` image tag in `docker-compose.yml` to `5.12.10-1`.

Fixes:
- https://github.com/mailcow/mailcow-dockerized/issues/7416

###  Affected Containers

- sogo-mailcow

## Did you run tests?

### What did you tested?

Built the sogo container with the new version and verified SOGo starts up and the webmail interface
