### PR TITLE
[Dovecot] Remove legacy DeltaChat auto-filing sieve rule

### DIFF
--- a/data/conf/dovecot/global_sieve_before
+++ b/data/conf/dovecot/global_sieve_before
@@ -1,13 +1,3 @@
 # global_sieve_before script
 # global_sieve_before -> user sieve_before (mailcow UI) -> user sieve_after (mailcow UI) -> global_sieve_after
 
-require ["mailbox", "fileinto"];
-
-if header :contains ["Chat-Version"] [""] {
-  if mailboxexists "DeltaChat" {
-    fileinto "DeltaChat";
-  } else {
-    fileinto :create "DeltaChat";
-  }
-  stop;
-}


### PR DESCRIPTION
## Contribution Guidelines

* [x] I've read the [contribution guidelines](https://github.com/mailcow/mailcow-dockerized/blob/master/CONTRIBUTING.md) and wholeheartedly agree them

## What does this PR include?

### Short Description

Removes the legacy DeltaChat auto-filing rule from `global_sieve_before`. It moved every message with a `Chat-Version` header into a `DeltaChat` folder and issued `stop;`. Modern DeltaChat only checks INBOX, so filing into a subfolder hides messages from the client, and the `stop;` additionally skipped user sieve rules. 

Fixes:
- #7418

###  Affected Containers

- dovecot-mailcow

